### PR TITLE
Fix fonte field typing

### DIFF
--- a/src/app/jrpedia/components/GlossaryForm.tsx
+++ b/src/app/jrpedia/components/GlossaryForm.tsx
@@ -10,17 +10,17 @@ type GlossaryFormProps = {
 
 export default function GlossaryForm({ initialData, onSave, onCancel }: GlossaryFormProps) {
   const [form, setForm] = useState<GlossaryRowInput>({
-    term: initialData?.term || "",
-    pt: initialData?.pt || "",
-    en: initialData?.en || "",
-    fr: initialData?.fr || "",
-    definition_pt: initialData?.definition_pt || "",
-    definition_en: initialData?.definition_en || "",
-    definition_fr: initialData?.definition_fr || "",
-    category: initialData?.category || "General",
-    fonte: initialData?.fonte || "",
-    tags: initialData?.tags || [],
-    parent_id: initialData?.parent_id || null,
+    term: initialData?.term ?? "",
+    pt: initialData?.pt ?? "",
+    en: initialData?.en ?? "",
+    fr: initialData?.fr ?? "",
+    definition_pt: initialData?.definition_pt ?? "",
+    definition_en: initialData?.definition_en ?? "",
+    definition_fr: initialData?.definition_fr ?? "",
+    category: initialData?.category ?? "General",
+    fonte: initialData?.fonte ?? "",
+    tags: initialData?.tags ?? [],
+    parent_id: initialData?.parent_id ?? null,
   });
 
   const [loading, setLoading] = useState(false);
@@ -89,7 +89,13 @@ export default function GlossaryForm({ initialData, onSave, onCancel }: Glossary
       {/* Fonte */}
       <div>
         <label className="block text-sm">Fonte</label>
-        <input name="fonte" value={form.fonte || ""} onChange={handleChange} className="border p-2 w-full rounded" />
+        <input
+          type="text"
+          name="fonte"
+          value={form.fonte}
+          onChange={handleChange}
+          className="border p-2 w-full rounded"
+        />
       </div>
 
       {/* Tags */}

--- a/src/app/jrpedia/page.tsx
+++ b/src/app/jrpedia/page.tsx
@@ -61,7 +61,17 @@ export default function JRpediaPage() {
     if (error) {
       console.error("Erro ao carregar termos:", error.message);
     } else if (data) {
-      setEntries(data);
+      const normalized = data.map((row) => ({
+        ...row,
+        fonte:
+          typeof row.fonte === "string"
+            ? row.fonte
+            : row.fonte != null
+            ? String(row.fonte)
+            : "",
+      })) as GlossaryRow[];
+
+      setEntries(normalized);
     }
   }, []);
 

--- a/src/app/jrpedia/types.ts
+++ b/src/app/jrpedia/types.ts
@@ -12,7 +12,7 @@ export type GlossaryRow = {
   definition_en: string | null;
   definition_fr: string | null;
   category: string | null;
-  fonte: string | null;
+  fonte: string;
   tags: string[] | null;
   parent_id?: number | null;
 };


### PR DESCRIPTION
## Summary
- change the glossary types so `fonte` is represented as a string
- ensure the glossary form stores and edits `fonte` as text input data
- normalize Supabase results so any non-string `fonte` values become strings

## Testing
- npm run lint
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d41c021da0832a8861cd8a621ff12f