### PR TITLE
feat(jrpedia): show real example in term view

### DIFF
--- a/src/app/jrpedia/components/TermView.tsx
+++ b/src/app/jrpedia/components/TermView.tsx
@@ -1,5 +1,14 @@
 "use client";
-import { GlossaryRow, Lang } from "../types";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@supabase/supabase-js";
+
+import { GlossaryRow, Lang, RealExample } from "../types";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+);
 
 type TermViewProps = {
   selectedTerm: GlossaryRow | null;
@@ -12,6 +21,46 @@ export default function TermView({
   selectedLang,
   isAdmin,
 }: TermViewProps) {
+  const [realExample, setRealExample] = useState<RealExample | null>(null);
+  const [isLoadingExample, setIsLoadingExample] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadExample = async () => {
+      if (!selectedTerm?.fonte) {
+        if (isMounted) {
+          setRealExample(null);
+        }
+        return;
+      }
+
+      setIsLoadingExample(true);
+      const { data, error } = await supabase
+        .from("all_data")
+        .select("composite_key, body_text")
+        .eq("composite_key", selectedTerm.fonte)
+        .maybeSingle();
+
+      if (!isMounted) return;
+
+      if (error && error.code !== "PGRST116") {
+        console.error("Erro ao buscar exemplo real:", error.message);
+        setRealExample(null);
+      } else {
+        setRealExample(data ?? null);
+      }
+
+      setIsLoadingExample(false);
+    };
+
+    loadExample();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedTerm?.fonte]);
+
   if (!selectedTerm) {
     return (
       <p className="text-gray-500">Selecione um termo na barra lateral.</p>
@@ -40,6 +89,35 @@ export default function TermView({
           ? selectedTerm.definition_en
           : selectedTerm.definition_fr}
       </p>
+
+      <div className="border-t pt-4 mt-4 space-y-3">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-600 uppercase tracking-wide">
+            Fonte
+          </h3>
+          <p className="text-gray-900">
+            {selectedTerm.fonte ? selectedTerm.fonte : "Sem fonte cadastrada."}
+          </p>
+        </div>
+
+        {isLoadingExample && (
+          <p className="text-sm text-gray-500">Carregando exemplo real...</p>
+        )}
+
+        {!isLoadingExample && realExample && (
+          <div className="rounded-lg border bg-gray-50 p-4">
+            <h4 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+              Exemplo real
+            </h4>
+            <p className="text-gray-900 whitespace-pre-line">
+              {realExample.body_text || "Sem conteúdo disponível."}
+            </p>
+            <p className="mt-2 text-xs text-gray-500">
+              Boletim: {realExample.composite_key}
+            </p>
+          </div>
+        )}
+      </div>
 
       {isAdmin && (
         <div className="mt-4 flex space-x-2">

--- a/src/app/jrpedia/types.ts
+++ b/src/app/jrpedia/types.ts
@@ -21,6 +21,11 @@ export type GlossaryRowInput = Omit<GlossaryRow, "id">;
 
 export type GlossaryNode = GlossaryRow & { children: GlossaryNode[] };
 
+export type RealExample = {
+  composite_key: string;
+  body_text: string | null;
+};
+
 export type SidebarProps = {
   tree: GlossaryNode[];
   selectedTerm: GlossaryRow | null;


### PR DESCRIPTION
## Summary
- fetch matching real-world example data from Supabase when displaying a glossary term
- render the fonte information and, when available, an example block sourced from all_data
- add a shared type definition to describe the fetched example structure

## Testing
- npm run lint
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d421b6697c832ab8b6c42ca1c05105