### PR TITLE
Restore JRpedia UI controls

### DIFF
--- a/src/app/jrpedia/components/CrudModals.tsx
+++ b/src/app/jrpedia/components/CrudModals.tsx
@@ -12,6 +12,7 @@ const supabase = createClient(
 export default function CrudModals({
   showNewModal,
   setShowNewModal,
+  newParentId,
   showEditModal,
   setShowEditModal,
   showDeleteModal,
@@ -29,6 +30,7 @@ export default function CrudModals({
         title="➕ Novo Termo"
       >
         <GlossaryForm
+          initialParentId={newParentId}
           onCancel={() => setShowNewModal(false)}
           onSave={async (formData: GlossaryRowInput) => {
             await supabase.from("glossary").insert(formData);

--- a/src/app/jrpedia/components/GlossaryForm.tsx
+++ b/src/app/jrpedia/components/GlossaryForm.tsx
@@ -1,14 +1,15 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { GlossaryRow, GlossaryRowInput } from "../types";
 
 type GlossaryFormProps = {
   initialData?: GlossaryRow;
+  initialParentId?: number | null;
   onSave: (data: GlossaryRowInput) => Promise<void>;
   onCancel: () => void;
 };
 
-export default function GlossaryForm({ initialData, onSave, onCancel }: GlossaryFormProps) {
+export default function GlossaryForm({ initialData, initialParentId, onSave, onCancel }: GlossaryFormProps) {
   const [form, setForm] = useState<GlossaryRowInput>({
     term: initialData?.term ?? "",
     pt: initialData?.pt ?? "",
@@ -20,10 +21,26 @@ export default function GlossaryForm({ initialData, onSave, onCancel }: Glossary
     category: initialData?.category ?? "General",
     fonte: initialData?.fonte ?? "",
     tags: initialData?.tags ?? [],
-    parent_id: initialData?.parent_id ?? null,
+    parent_id: initialData?.parent_id ?? initialParentId ?? null,
   });
 
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setForm({
+      term: initialData?.term ?? "",
+      pt: initialData?.pt ?? "",
+      en: initialData?.en ?? "",
+      fr: initialData?.fr ?? "",
+      definition_pt: initialData?.definition_pt ?? "",
+      definition_en: initialData?.definition_en ?? "",
+      definition_fr: initialData?.definition_fr ?? "",
+      category: initialData?.category ?? "General",
+      fonte: initialData?.fonte ?? "",
+      tags: initialData?.tags ?? [],
+      parent_id: initialData?.parent_id ?? initialParentId ?? null,
+    });
+  }, [initialData, initialParentId]);
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     const { name, value } = e.target;

--- a/src/app/jrpedia/components/Sidebar.tsx
+++ b/src/app/jrpedia/components/Sidebar.tsx
@@ -1,19 +1,13 @@
 "use client";
 import { useEffect, useState } from "react";
-import { GlossaryRow, GlossaryNode, Lang } from "../types";
-
-type SidebarProps = {
-  tree: GlossaryNode[];
-  selectedTerm: GlossaryRow | null;
-  setSelectedTerm: (t: GlossaryRow) => void;
-  selectedLang: Lang;
-};
+import { GlossaryRow, GlossaryNode, SidebarProps } from "../types";
 
 export default function Sidebar({
   tree,
   selectedTerm,
   setSelectedTerm,
   selectedLang,
+  onAddTerm,
 }: SidebarProps) {
   function TreeNode({
     node,
@@ -69,7 +63,17 @@ export default function Sidebar({
 
   return (
     <aside className="w-64 bg-[#1e2a38] text-white flex flex-col p-3 overflow-y-auto">
-      <h3 className="font-bold text-[#d4af37] mb-2">JRpedia</h3>
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-bold text-[#d4af37]">JRpedia</h3>
+        <button
+          type="button"
+          onClick={onAddTerm}
+          className="flex h-7 w-7 items-center justify-center rounded bg-[#d4af37] text-black font-bold hover:bg-[#f0c75e]"
+          aria-label="Adicionar novo termo"
+        >
+          +
+        </button>
+      </div>
       {tree.map((node) => (
         <TreeNode key={node.id} node={node} activeTerm={selectedTerm} />
       ))}

--- a/src/app/jrpedia/types.ts
+++ b/src/app/jrpedia/types.ts
@@ -1,3 +1,5 @@
+import { Dispatch, SetStateAction } from "react";
+
 // src/app/jrpedia/types.ts
 
 export type Lang = "pt" | "en" | "fr";
@@ -29,8 +31,9 @@ export type RealExample = {
 export type SidebarProps = {
   tree: GlossaryNode[];
   selectedTerm: GlossaryRow | null;
-  setSelectedTerm: (t: GlossaryRow | null) => void;
+  setSelectedTerm: Dispatch<SetStateAction<GlossaryRow | null>>;
   selectedLang: Lang;
+  onAddTerm: () => void;
 };
 
 export type TermViewProps = {
@@ -41,10 +44,11 @@ export type TermViewProps = {
 
 export type CrudModalsProps = {
   selectedTerm: GlossaryRow | null;
-  setSelectedTerm: (t: GlossaryRow | null) => void;
+  setSelectedTerm: Dispatch<SetStateAction<GlossaryRow | null>>;
   fetchEntries: () => void;
   showNewModal: boolean;
   setShowNewModal: (v: boolean) => void;
+  newParentId: number | null;
   showEditModal: boolean;
   setShowEditModal: (v: boolean) => void;
   showDeleteModal: boolean;


### PR DESCRIPTION
## Summary
- add the JRpedia sidebar action button and plumb it into the glossary modal flow
- wire the login key icon to the PasswordModal while keeping the admin exit control
- allow GlossaryForm and CRUD modals to prefill parent relationships for new terms

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: missing NEXT_PUBLIC_SUPABASE_URL/NEXT_PUBLIC_SUPABASE_ANON_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68d433463aec832aa0c99e79cbb38646