### PR TITLE
Refine JRpedia admin controls and term management

### DIFF
--- a/src/app/jrpedia/components/CrudModals.tsx
+++ b/src/app/jrpedia/components/CrudModals.tsx
@@ -15,10 +15,7 @@ export default function CrudModals({
   newParentId,
   showEditModal,
   setShowEditModal,
-  showDeleteModal,
-  setShowDeleteModal,
   selectedTerm,
-  setSelectedTerm,
   fetchEntries,
 }: CrudModalsProps) {
   return (
@@ -56,40 +53,6 @@ export default function CrudModals({
               fetchEntries();
             }}
           />
-        )}
-      </Modal>
-
-      {/* Excluir */}
-      <Modal
-        isOpen={showDeleteModal}
-        onClose={() => setShowDeleteModal(false)}
-        title="🗑 Excluir Termo"
-      >
-        {selectedTerm && (
-          <div>
-            <p>
-              Tem certeza que deseja excluir <b>{selectedTerm.term}</b>?
-            </p>
-            <div className="flex justify-end space-x-2 mt-4">
-              <button
-                onClick={() => setShowDeleteModal(false)}
-                className="px-3 py-1 bg-gray-300 rounded"
-              >
-                Cancelar
-              </button>
-              <button
-                onClick={async () => {
-                  await supabase.from("glossary").delete().eq("id", selectedTerm.id);
-                  setSelectedTerm(null);
-                  setShowDeleteModal(false);
-                  fetchEntries();
-                }}
-                className="px-3 py-1 bg-red-600 text-white rounded"
-              >
-                Confirmar
-              </button>
-            </div>
-          </div>
         )}
       </Modal>
     </>

--- a/src/app/jrpedia/page.tsx
+++ b/src/app/jrpedia/page.tsx
@@ -52,7 +52,6 @@ export default function JRpediaPage() {
   // estados dos modais
   const [showNewModal, setShowNewModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [newTermParentId, setNewTermParentId] = useState<number | null>(null);
 
   // Fetch de dados
@@ -164,28 +163,27 @@ export default function JRpediaPage() {
               ))}
             </div>
 
-            {isAdmin ? (
-              <button
-                type="button"
-                onClick={handleExitAdmin}
-                className="px-3 py-1 rounded font-medium transition bg-red-100 text-red-700 hover:bg-red-200"
-              >
-                Sair do modo admin
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setNewTermParentId(null);
-                  setShouldOpenCreateAfterLogin(false);
-                  setShowPasswordModal(true);
-                }}
-                className="flex h-9 w-9 items-center justify-center rounded bg-green-100 text-lg transition hover:bg-green-200"
-                aria-label="Entrar como admin"
-              >
-                🔑
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={() => {
+                if (isAdmin) {
+                  handleExitAdmin();
+                  return;
+                }
+
+                setNewTermParentId(null);
+                setShouldOpenCreateAfterLogin(false);
+                setShowPasswordModal(true);
+              }}
+              className={`flex h-9 w-9 items-center justify-center rounded text-lg font-medium transition ${
+                isAdmin
+                  ? "bg-red-100 text-red-600 hover:bg-red-200"
+                  : "bg-green-100 text-green-600 hover:bg-green-200"
+              }`}
+              aria-label={isAdmin ? "Sair do modo admin" : "Entrar como admin"}
+            >
+              🔑
+            </button>
           </div>
         </div>
 
@@ -199,6 +197,11 @@ export default function JRpediaPage() {
             selectedTerm={selectedTerm}
             selectedLang={selectedLang}
             isAdmin={isAdmin}
+            onEditTerm={() => setShowEditModal(true)}
+            onDeleteSuccess={() => {
+              setSelectedTerm(null);
+              fetchEntries();
+            }}
           />
         )}
       </main>
@@ -211,10 +214,7 @@ export default function JRpediaPage() {
           newParentId={newTermParentId}
           showEditModal={showEditModal}
           setShowEditModal={setShowEditModal}
-          showDeleteModal={showDeleteModal}
-          setShowDeleteModal={setShowDeleteModal}
           selectedTerm={selectedTerm}
-          setSelectedTerm={setSelectedTerm}
           fetchEntries={fetchEntries}
         />
       )}

--- a/src/app/jrpedia/types.ts
+++ b/src/app/jrpedia/types.ts
@@ -40,17 +40,16 @@ export type TermViewProps = {
   selectedTerm: GlossaryRow | null;
   selectedLang: Lang;
   isAdmin: boolean;
+  onEditTerm: () => void;
+  onDeleteSuccess: () => void;
 };
 
 export type CrudModalsProps = {
   selectedTerm: GlossaryRow | null;
-  setSelectedTerm: Dispatch<SetStateAction<GlossaryRow | null>>;
   fetchEntries: () => void;
   showNewModal: boolean;
   setShowNewModal: (v: boolean) => void;
   newParentId: number | null;
   showEditModal: boolean;
   setShowEditModal: (v: boolean) => void;
-  showDeleteModal: boolean;
-  setShowDeleteModal: (v: boolean) => void;
 };


### PR DESCRIPTION
## Summary
- update JRpedia page to toggle admin mode with a key icon and wire edit/delete callbacks into TermView
- simplify CrudModals to focus on create/edit flows and expose the selected term to TermView through new props
- add inline delete confirmation in TermView that removes the selected glossary term via Supabase and refreshes the listing

## Testing
- tsc --noEmit
- CI=1 NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_KEY=dummy npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43c5b2558832a86d1ff695534b6b9