### PR TITLE
Refine JRpedia sidebar expansion handling

### DIFF
--- a/src/app/jrpedia/components/Sidebar.tsx
+++ b/src/app/jrpedia/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { GlossaryRow, GlossaryNode, SidebarProps } from "../types";
 
 export default function Sidebar({
@@ -9,6 +9,51 @@ export default function Sidebar({
   selectedLang,
   onAddTerm,
 }: SidebarProps) {
+  const [expandedNodeIds, setExpandedNodeIds] = useState<Set<number>>(
+    () => new Set(),
+  );
+
+  const findPathToNode = useCallback(
+    (nodes: GlossaryNode[], targetId: number): GlossaryNode[] | null => {
+      for (const node of nodes) {
+        if (node.id === targetId) {
+          return [node];
+        }
+
+        if (node.children.length > 0) {
+          const childPath = findPathToNode(node.children, targetId);
+          if (childPath) {
+            return [node, ...childPath];
+          }
+        }
+      }
+
+      return null;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!selectedTerm) return;
+
+    const pathNodes = findPathToNode(tree, selectedTerm.id);
+    if (!pathNodes) return;
+
+    setExpandedNodeIds((prev) => {
+      let shouldUpdate = false;
+      const next = new Set(prev);
+
+      pathNodes.forEach((pathNode) => {
+        if (pathNode.children.length > 0 && !next.has(pathNode.id)) {
+          next.add(pathNode.id);
+          shouldUpdate = true;
+        }
+      });
+
+      return shouldUpdate ? next : prev;
+    });
+  }, [findPathToNode, selectedTerm, tree]);
+
   function TreeNode({
     node,
     activeTerm,
@@ -16,41 +61,51 @@ export default function Sidebar({
     node: GlossaryNode
     activeTerm: GlossaryRow | null
   }) {
-    const [collapsed, setCollapsed] = useState(true);
+    const hasChildren = node.children.length > 0;
+    const isExpanded = expandedNodeIds.has(node.id);
     const isSelected = activeTerm?.id === node.id;
+    const label = node[selectedLang] || node.term;
+    const normalizedLabel = label?.trim();
+    const isTsxvNode =
+      node.term.toUpperCase() === "TSXV" ||
+      normalizedLabel?.toUpperCase() === "TSXV";
 
-    // 🔑 Mantém o caminho expandido se o termo selecionado estiver neste branch
-    useEffect(() => {
-      if (!activeTerm) return;
+    const handleClick = () => {
+      if (isTsxvNode) {
+        setExpandedNodeIds(new Set());
+        return;
+      }
 
-      const expandPath = (n: GlossaryNode): boolean => {
-        if (n.id === activeTerm.id) return true;
-        return n.children.some(expandPath);
-      };
+      if (hasChildren) {
+        setExpandedNodeIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(node.id)) {
+            next.delete(node.id);
+          } else {
+            next.add(node.id);
+          }
+          return next;
+        });
+        return;
+      }
 
-      if (expandPath(node)) setCollapsed(false);
-    }, [activeTerm, node]);
+      setSelectedTerm(node);
+    };
 
     return (
       <div className="ml-2">
         <button
-          onClick={() => {
-            if (node.children.length > 0) {
-              setCollapsed(!collapsed);
-            } else {
-              setSelectedTerm(node);
-            }
-          }}
+          onClick={handleClick}
           className={`block w-full text-left px-2 py-1 rounded ${
             isSelected
               ? "bg-[#d4af37] text-black font-bold"
               : "hover:bg-[#2e3b4a]"
           }`}
         >
-          {node[selectedLang] || node.term}
+          {normalizedLabel || node.term}
         </button>
 
-        {!collapsed && node.children.length > 0 && (
+        {hasChildren && isExpanded && (
           <div className="ml-4 border-l border-gray-600 pl-2">
             {node.children.map((child) => (
               <TreeNode key={child.id} node={child} activeTerm={activeTerm} />


### PR DESCRIPTION
## Summary
- replace per-node collapse state with a shared expanded node id set
- ensure the tree opens the path for the active term without altering manual toggles or language switches
- add a TSXV shortcut that clears all expanded branches

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d45f14d364832a8dc8446c8cbec35e