### PR TITLE
Highlight glossary terms in bulletin details

### DIFF
--- a/src/app/jrpedia/page.tsx
+++ b/src/app/jrpedia/page.tsx
@@ -202,6 +202,7 @@ export default function JRpediaPage() {
               setSelectedTerm(null);
               fetchEntries();
             }}
+            glossaryData={entries}
           />
         )}
       </main>

--- a/src/app/jrpedia/types.ts
+++ b/src/app/jrpedia/types.ts
@@ -42,6 +42,7 @@ export type TermViewProps = {
   isAdmin: boolean;
   onEditTerm: () => void;
   onDeleteSuccess: () => void;
+  glossaryData: GlossaryRow[];
 };
 
 export type CrudModalsProps = {


### PR DESCRIPTION
## Summary
- add a helper in `TermView` to escape bulletin text and wrap glossary terms and tags with a yellow `<mark>`
- render bulletin details with `dangerouslySetInnerHTML` so the highlighted markup is displayed
- pass the full glossary dataset into `TermView` for highlighting context and extend the component props

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: Supabase credentials are not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5350a5888832a85fcaaba9a9ff400