### PR TITLE
Limit JRpedia highlight scope

### DIFF
--- a/src/app/jrpedia/page.tsx
+++ b/src/app/jrpedia/page.tsx
@@ -202,7 +202,6 @@ export default function JRpediaPage() {
               setSelectedTerm(null);
               fetchEntries();
             }}
-            glossaryData={entries}
           />
         )}
       </main>

--- a/src/app/jrpedia/types.ts
+++ b/src/app/jrpedia/types.ts
@@ -42,7 +42,6 @@ export type TermViewProps = {
   isAdmin: boolean;
   onEditTerm: () => void;
   onDeleteSuccess: () => void;
-  glossaryData: GlossaryRow[];
 };
 
 export type CrudModalsProps = {


### PR DESCRIPTION
## Summary
- restrict TermView highlighting to the active glossary term and its tags
- remove the unused glossaryData prop now that highlighting is scoped to the selected term

## Testing
- `tsc --noEmit`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68d53b487ee4832aa9f44b9349354db7