### PR TITLE
Add whiteboard sandbox and navigation link

### DIFF
--- a/src/app/jrpedia/components/WhiteboardSandbox.tsx
+++ b/src/app/jrpedia/components/WhiteboardSandbox.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+import { createClient } from "@supabase/supabase-js";
+
+const Excalidraw = dynamic<any>(
+  async () => (await import("@excalidraw/excalidraw")).Excalidraw,
+  { ssr: false }
+);
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+export default function WhiteboardSandbox() {
+  const [scene, setScene] = useState<any>(null);
+
+  async function saveScene() {
+    if (!scene) return;
+    const { error } = await supabase.from("whiteboards").insert({
+      name: "Minha Lousa",
+      data: scene,
+    });
+    if (error) console.error(error);
+    else alert("Lousa salva!");
+  }
+
+  return (
+    <div style={{ height: "100vh" }}>
+      <Excalidraw
+        initialData={{ elements: [], appState: { theme: "light" } }}
+        onChange={(elements: any, appState: any, files: any) =>
+          setScene({ elements, appState, files })
+        }
+      />
+      <button
+        onClick={saveScene}
+        style={{
+          position: "absolute",
+          top: 10,
+          right: 10,
+          background: "black",
+          color: "white",
+          padding: "8px 12px",
+          borderRadius: "6px",
+        }}
+      >
+        Salvar no Supabase
+      </button>
+    </div>
+  );
+}

--- a/src/app/sandbox/whiteboard/page.tsx
+++ b/src/app/sandbox/whiteboard/page.tsx
@@ -1,0 +1,5 @@
+import WhiteboardSandbox from "@/app/jrpedia/components/WhiteboardSandbox";
+
+export default function Page() {
+  return <WhiteboardSandbox />;
+}

--- a/src/app/sidebar.tsx
+++ b/src/app/sidebar.tsx
@@ -130,6 +130,12 @@ export default function Sidebar() {
             >
               - Em construção
             </Link>
+            <Link
+              href="/sandbox/whiteboard"
+              className={`transition-colors ${pathname === "/sandbox/whiteboard" ? "text-white" : "hover:text-white"}`}
+            >
+              - Whiteboard
+            </Link>
           </div>
         )}
 

--- a/src/types/excalidraw.d.ts
+++ b/src/types/excalidraw.d.ts
@@ -1,0 +1,1 @@
+declare module "@excalidraw/excalidraw";


### PR DESCRIPTION
## Summary
- add a Sandbox submenu entry for the Whiteboard workspace
- implement the Whiteboard sandbox client component with Supabase persistence
- expose the sandbox page and declare the Excalidraw module type stub

## Testing
- `tsc --noEmit`
- `npm run build` *(fails: @excalidraw/excalidraw package is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d73f677fac832aa13b45d65f89094f