### PR TITLE
Implement Supabase-backed whiteboard sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-resizable": "^3.0.5",
     "react-select": "^5.10.2",
     "recharts": "^3.2.1",
-    "@excalidraw/excalidraw": "^0.17.6"
+    "@excalidraw/excalidraw": "^0.19.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/jrpedia/components/WhiteboardSandbox.tsx
+++ b/src/app/jrpedia/components/WhiteboardSandbox.tsx
@@ -114,7 +114,7 @@ export default function WhiteboardSandbox() {
   return (
     <div style={{ height: "100vh" }}>
       <Excalidraw
-        ref={(api) => {
+        excalidrawAPI={(api) => {
           if (api) {
             excalidrawRef.current = api;
           }

--- a/src/app/jrpedia/components/WhiteboardSandbox.tsx
+++ b/src/app/jrpedia/components/WhiteboardSandbox.tsx
@@ -114,7 +114,7 @@ export default function WhiteboardSandbox() {
   return (
     <div style={{ height: "100vh" }}>
       <Excalidraw
-        ref={excalidrawRef}
+        excalidrawRef={excalidrawRef}
         viewModeEnabled={!isAdmin}
         initialData={initialData ?? { elements: [], appState: { theme: "light" } }}
         onChange={(

--- a/src/app/jrpedia/components/WhiteboardSandbox.tsx
+++ b/src/app/jrpedia/components/WhiteboardSandbox.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
 import { createClient } from "@supabase/supabase-js";
-import type { ExcalidrawAPI } from "@excalidraw/excalidraw";
+import type { ExcalidrawImperativeAPI as ExcalidrawAPI } from "@excalidraw/excalidraw/types/types";
 import type { ExcalidrawElement } from "@excalidraw/excalidraw/types/element/types";
 import type { AppState, BinaryFileData } from "@excalidraw/excalidraw/types/types";
 

--- a/src/app/jrpedia/components/WhiteboardSandbox.tsx
+++ b/src/app/jrpedia/components/WhiteboardSandbox.tsx
@@ -3,12 +3,9 @@
 import { useState, useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
 import { createClient } from "@supabase/supabase-js";
-import type {
-  ExcalidrawElement,
-  AppState,
-  BinaryFileData,
-  ExcalidrawAPI,
-} from "@excalidraw/excalidraw";
+import type { ExcalidrawAPI } from "@excalidraw/excalidraw";
+import type { ExcalidrawElement } from "@excalidraw/excalidraw/types/element/types";
+import type { AppState, BinaryFileData } from "@excalidraw/excalidraw/types/types";
 
 const Excalidraw = dynamic(
   async () => (await import("@excalidraw/excalidraw")).Excalidraw,
@@ -171,3 +168,4 @@ export default function WhiteboardSandbox() {
     </div>
   );
 }
+

--- a/src/app/jrpedia/components/WhiteboardSandbox.tsx
+++ b/src/app/jrpedia/components/WhiteboardSandbox.tsx
@@ -114,7 +114,11 @@ export default function WhiteboardSandbox() {
   return (
     <div style={{ height: "100vh" }}>
       <Excalidraw
-        excalidrawRef={excalidrawRef}
+        ref={(api) => {
+          if (api) {
+            excalidrawRef.current = api;
+          }
+        }}
         viewModeEnabled={!isAdmin}
         initialData={initialData ?? { elements: [], appState: { theme: "light" } }}
         onChange={(


### PR DESCRIPTION
## Summary
- replace the whiteboard sandbox with a Supabase-backed Excalidraw integration
- add admin-gated editing, save, and export controls for the shared board

## Testing
- tsc --noEmit *(fails: missing @excalidraw/excalidraw types in the project)*
- npm run build *(fails: module '@excalidraw/excalidraw' is not installed in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d7490d924c832ab42e48070cc4ac14