### PR TITLE
Adjust JRpedia main panel styling and replace whiteboard sandbox

### DIFF
--- a/src/app/jrpedia/page.tsx
+++ b/src/app/jrpedia/page.tsx
@@ -130,7 +130,7 @@ export default function JRpediaPage() {
       />
 
       {/* Main panel */}
-      <main className="flex-1 p-6 overflow-y-auto">
+      <main className="flex-1 border-l border-gray-300 shadow-inner px-6 py-4 overflow-y-auto">
         <div className="flex justify-between items-center mb-4">
           {/* título */}
           <h1 className="text-2xl font-bold">JRpedia</h1>

--- a/src/app/sandbox/whiteboard/page.tsx
+++ b/src/app/sandbox/whiteboard/page.tsx
@@ -1,5 +1,8 @@
-import WhiteboardSandbox from "@/app/jrpedia/components/WhiteboardSandbox";
-
-export default function Page() {
-  return <WhiteboardSandbox />;
+export default function WhiteboardPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold">Whiteboard</h1>
+      <p className="text-gray-600">Funcionalidade em construção.</p>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- refine the JRpedia main panel spacing with separate horizontal and vertical padding
- add a subtle left border and inner shadow to frame the content area
- replace the removed whiteboard sandbox import with a placeholder message to keep the route functional

## Testing
- `npx tsc` *(fails: existing JSX intrinsic element type errors across the project)*
- `npm run build` *(fails: `next` binary not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d80cd59bd4832a941a4f6f32a346bb