### PR TITLE
Adjust JRpedia main panel styling

### DIFF
--- a/src/app/jrpedia/page.tsx
+++ b/src/app/jrpedia/page.tsx
@@ -130,7 +130,7 @@ export default function JRpediaPage() {
       />
 
       {/* Main panel */}
-      <main className="flex-1 border-l border-gray-300 shadow-inner px-6 py-4 overflow-y-auto">
+      <main className="flex-1 ml-1 rounded-md border border-gray-300 shadow-sm bg-white px-6 py-4 overflow-y-auto">
         <div className="flex justify-between items-center mb-4">
           {/* título */}
           <h1 className="text-2xl font-bold">JRpedia</h1>


### PR DESCRIPTION
## Summary
- add a subtle margin, rounded border, and shadow to the JRpedia main panel for better separation from the sidebar

## Testing
- git pull *(fails: no tracking information for the current branch)*
- npm run tsc *(fails: missing script "tsc")*
- npx tsc *(fails: existing TypeScript errors in unrelated files)*
- npm run build *(fails: `next` binary not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d830a39414832a84cd11d4751bbd5b