### PR TITLE
Adjust global layout spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,18 @@
   }
 }
 
+html,
+body {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  /* 🔹 Respiro global entre barra do navegador e app */
+  padding-top: 8px; /* ajuste conforme preferência */
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/jrpedia/components/Sidebar.tsx
+++ b/src/app/jrpedia/components/Sidebar.tsx
@@ -74,7 +74,7 @@ export default function Sidebar({
   }
 
   return (
-    <aside className="flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm">
+    <aside className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm">
       <div className="flex items-center justify-between px-3 pt-4 pb-2">
         <h3 className="text-lg font-bold text-[#d4af37]">JRpedia</h3>
         <button


### PR DESCRIPTION
## Summary
- add global html/body padding and smoothing reset to introduce top spacing
- apply a small left margin to the JRpedia sidebar for visual breathing room

## Testing
- `git pull` *(fails: no upstream configured for work branch)*
- `npx tsc --noEmit` *(fails: missing type definition packages such as @types/node, d3, react, etc.)*
- `npx vercel build` *(fails: npm 403 when installing vercel package from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d888aeb5d4832abfd61fc640e627e7