### PR TITLE
Add global padding and adjust JRpedia sidebar spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,12 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  /* 🔹 Respiro global entre barra do navegador e app */
+  padding-top: 8px; /* ajuste conforme necessidade */
 }
 
 /* Scrollbar customizada para Sidebar JRpedia */

--- a/src/app/jrpedia/components/Sidebar.tsx
+++ b/src/app/jrpedia/components/Sidebar.tsx
@@ -74,7 +74,9 @@ export default function Sidebar({
   }
 
   return (
-    <aside className="flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm">
+    <aside
+      className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm"
+    >
       <div className="flex items-center justify-between px-3 pt-4 pb-2">
         <h3 className="text-lg font-bold text-[#d4af37]">JRpedia</h3>
         <button


### PR DESCRIPTION
## Summary
- add top padding to the global body styles to introduce space beneath the browser chrome
- restore the JRpedia sidebar margin configuration while keeping formatting tidy

## Testing
- npx tsc --noEmit *(fails: pre-existing type errors in multiple files)*
- npx vercel build *(fails: npm 403 when fetching vercel package)*

------
https://chatgpt.com/codex/tasks/task_e_68d88a3de434832ab265bedbb64607a9