### PR TITLE
Adjust JRpedia layout spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,7 +28,7 @@ body {
   margin: 0;
   padding: 0;
   /* 🔹 Respiro global entre barra do navegador e app */
-  padding-top: 16px; /* padronizado */
+  padding-top: 8px; /* padronizado menor */
 }
 
 /* Scrollbar customizada para Sidebar JRpedia */

--- a/src/app/jrpedia/components/Sidebar.tsx
+++ b/src/app/jrpedia/components/Sidebar.tsx
@@ -75,7 +75,7 @@ export default function Sidebar({
 
   return (
     <aside
-      className="ml-4 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm"
+      className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm"
     >
       <div className="flex items-center justify-between px-3 pt-4 pb-2">
         <h3 className="text-lg font-bold text-[#d4af37]">JRpedia</h3>

--- a/src/app/jrpedia/page.tsx
+++ b/src/app/jrpedia/page.tsx
@@ -130,7 +130,7 @@ export default function JRpediaPage() {
       />
 
       {/* Main panel */}
-      <main className="flex-1 ml-4 rounded-md border border-gray-300 shadow-sm bg-white px-6 py-4 overflow-y-auto">
+      <main className="flex-1 ml-2 rounded-md border border-gray-300 shadow-sm bg-white px-6 py-4 overflow-y-auto">
         <div className="flex justify-between items-center mb-4">
           {/* título */}
           <h1 className="text-2xl font-bold">JRpedia</h1>


### PR DESCRIPTION
## Summary
- reduce the global top padding to tighten the layout spacing
- decrease the left margin on the JRpedia sidebar and main panel for a more compact view

## Testing
- `git pull` *(fails: no tracking information is configured for the work branch)*
- `npx tsc --noEmit` *(fails: existing TypeScript errors in multiple files including sandbox and warnings pages)*
- `npx vercel build` *(fails: npm registry returned 403 Forbidden for the vercel package)*

------
https://chatgpt.com/codex/tasks/task_e_68d88dfb11c0832a9375d79639c7ec8f