### PR TITLE
Limit glossary parent tree depth

### DIFF
--- a/src/app/jrpedia/components/GlossaryForm.tsx
+++ b/src/app/jrpedia/components/GlossaryForm.tsx
@@ -29,12 +29,17 @@ function buildTree(
   nodes: ParentNode[],
   parentId: number | null = null,
   level: number = 0,
+  maxDepth: number = 1,
 ): ParentOption[] {
+  if (level > maxDepth) {
+    return [];
+  }
+
   return nodes
     .filter((node) => node.parent_id === parentId)
     .flatMap((node) => [
       { value: node.id, label: `${"— ".repeat(level)}${node.term}` },
-      ...buildTree(nodes, node.id, level + 1),
+      ...buildTree(nodes, node.id, level + 1, maxDepth),
     ]);
 }
 


### PR DESCRIPTION
## Summary
- restrict the recursive glossary parent tree builder to only include nodes up to a fixed depth

## Testing
- npx tsc --noEmit
- npx vercel build *(fails: npm error 403 fetching vercel package)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a4d92310832a90e0f302bee9a5ff