### PR TITLE
Support highlighting of multi-word terms

### DIFF
--- a/src/app/jrpedia/components/TermView.tsx
+++ b/src/app/jrpedia/components/TermView.tsx
@@ -52,7 +52,8 @@ function highlightWithTags(
 
       try {
         const escapedPattern = escapeRegExp(value);
-        const regex = new RegExp(`(?<!&)\\b(${escapedPattern})\\b`, "i");
+        // Sem \b para suportar termos compostos (ex: "common shares")
+        const regex = new RegExp(`(${escapedPattern})`, "i");
         const newResult = result.replace(
           regex,
           `<mark class="${className}">$1</mark>`,


### PR DESCRIPTION
## Summary
- adjust JRpedia term highlighting to drop word-boundary anchors so multi-word phrases are matched
- document the intent directly in the component to clarify the behavior change

## Testing
- `npx tsc --noEmit`
- `npx vercel build` *(fails: npm error code E403 when downloading vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68d94a5f9808832ab031beee76cc576b