### PR TITLE
Update tag highlight colors for term view

### DIFF
--- a/src/app/jrpedia/components/TermView.tsx
+++ b/src/app/jrpedia/components/TermView.tsx
@@ -81,10 +81,12 @@ function highlightWithTags(
 
   const patterns = [
     { value: term.term, className: "bg-yellow-200" },
-    ...(term.tags ?? []).map((t) => ({
-      value: t,
-      className: "bg-green-200",
-    })),
+    ...(term.tags ?? []).map((t, i) => {
+      let className = "bg-gray-200"; // padrão
+      if (i === 0) className = "bg-green-200"; // primeira tag
+      else if (i === 1) className = "bg-blue-200"; // segunda tag
+      return { value: t, className };
+    }),
   ].filter((p) => p.value && p.value.trim().length > 0);
 
   const bodyHighlighted = body ? applyHighlight(body, patterns) : "";


### PR DESCRIPTION
## Summary
- update tag highlight color selection to vary by tag position in TermView

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d954f338a8832a861020d2263ee942