### PR TITLE
fix(jrpedia): restore highlight colors for tags

### DIFF
--- a/src/app/jrpedia/components/TermView.tsx
+++ b/src/app/jrpedia/components/TermView.tsx
@@ -81,12 +81,7 @@ function highlightWithTags(
 
   const patterns = [
     { value: term.term, className: "bg-yellow-200" },
-    ...(term.tags ?? []).map((t, i) => {
-      let className = "bg-gray-200"; // padrão
-      if (i === 0) className = "bg-green-200"; // primeira tag
-      else if (i === 1) className = "bg-blue-200"; // segunda tag
-      return { value: t, className };
-    }),
+    ...(term.tags ?? []).map((t) => ({ value: t, className: "bg-green-200" })),
   ].filter((p) => p.value && p.value.trim().length > 0);
 
   const bodyHighlighted = body ? applyHighlight(body, patterns) : "";


### PR DESCRIPTION
## Summary
- ensure term highlight prioritizes the body text before falling back to the header
- restore highlight colors to yellow for the base term and green for tags while keeping escaping safeguards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9560b05d4832a8e9fe4c655db6c6d