### PR TITLE
Sort JRpedia tree by selected language

### DIFF
--- a/src/app/jrpedia/page.tsx
+++ b/src/app/jrpedia/page.tsx
@@ -35,6 +35,20 @@ function buildTree(rows: GlossaryRow[]): GlossaryNode[] {
   return roots;
 }
 
+// ---------------------- Sort helper ----------------------
+function sortTree(nodes: GlossaryNode[], lang: Lang): GlossaryNode[] {
+  return [...nodes]
+    .sort((a, b) => {
+      const labelA = (a[lang] || a.term || "").toLowerCase();
+      const labelB = (b[lang] || b.term || "").toLowerCase();
+      return labelA.localeCompare(labelB);
+    })
+    .map((n) => ({
+      ...n,
+      children: sortTree(n.children, lang),
+    }));
+}
+
 // ---------------------- JRpedia Page ----------------------
 export default function JRpediaPage() {
   const [entries, setEntries] = useState<GlossaryRow[]>([]);
@@ -116,7 +130,7 @@ export default function JRpediaPage() {
       .some((val) => val!.toLowerCase().includes(searchTerm.toLowerCase()))
   );
 
-  const tree = buildTree(filteredEntries);
+  const tree = sortTree(buildTree(filteredEntries), selectedLang);
 
   return (
     <div className="flex h-screen bg-[#fdf8f0]">


### PR DESCRIPTION
## Summary
- add a `sortTree` helper to order glossary nodes by the currently selected language label
- apply the recursive sort when building the tree so the sidebar updates ordering on language changes

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d96c9a78e8832a9f005f82177ec28d