### PR TITLE
Preserve header formatting in TermView body normalization

### DIFF
--- a/src/app/jrpedia/components/TermView.tsx
+++ b/src/app/jrpedia/components/TermView.tsx
@@ -83,10 +83,16 @@ function highlightWithTags(
 
 function normalizeBodyText(raw: string): string {
   const [header, ...rest] = raw.split(/\n\s*\n/);
+
+  // Cabeçalho deve ser preservado exatamente como veio (mantém quebras originais)
+  const fixedHeader = header || "";
+
+  // Corpo: cada parágrafo vira linha corrido, mantendo apenas parágrafos separados
   const normalizedRest = rest
     .map((par) => par.replace(/\n+/g, " "))
     .join("\n\n");
-  return [header, normalizedRest].filter(Boolean).join("\n\n");
+
+  return [fixedHeader, normalizedRest].filter(Boolean).join("\n\n");
 }
 
 function splitDualLanguage(text: string): { en: string; fr: string | null } {


### PR DESCRIPTION
## Summary
- keep the header section untouched while normalizing body paragraphs in TermView

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da027a6374832ab6e6fe414bc8590f