### PR TITLE
Introduce Data Mining section with internal navigation

### DIFF
--- a/src/app/datamining/bulletins/page.tsx
+++ b/src/app/datamining/bulletins/page.tsx
@@ -33,7 +33,7 @@ type Row = {
 
 type Option = { value: string; label: string }
 
-export default function ReportsPage() {
+export default function BulletinsPage() {
   const [rows, setRows] = useState<Row[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedCompanies, setSelectedCompanies] = useState<string[]>([])

--- a/src/app/datamining/components/Sidebar.tsx
+++ b/src/app/datamining/components/Sidebar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+type SidebarProps = {
+  selectedReport: string | null;
+  setSelectedReport: (report: string) => void;
+};
+
+export default function Sidebar({ selectedReport, setSelectedReport }: SidebarProps) {
+  const reports = ["Bulletins", "Placeholder"];
+
+  return (
+    <div className="w-64 bg-[#1e2a38] text-white h-full p-4">
+      <h2 className="text-lg font-bold mb-4">Data Mining</h2>
+      <ul>
+        {reports.map((r) => (
+          <li key={r}>
+            <button
+              onClick={() => setSelectedReport(r)}
+              className={`block w-full text-left px-2 py-1 rounded ${
+                selectedReport === r ? "bg-[#d4af37] text-black" : "hover:bg-[#2e3b4a]"
+              }`}
+            >
+              {r}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/datamining/page.tsx
+++ b/src/app/datamining/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useState } from "react";
+import Sidebar from "./components/Sidebar";
+import BulletinsPage from "./bulletins/page";
+import PlaceholderPage from "./placeholder/page";
+
+export default function DataMiningPage() {
+  const [selectedReport, setSelectedReport] = useState<string>("Bulletins");
+
+  return (
+    <div className="flex h-screen">
+      <Sidebar selectedReport={selectedReport} setSelectedReport={setSelectedReport} />
+      <div className="flex-1 overflow-y-auto">
+        {selectedReport === "Bulletins" && <BulletinsPage />}
+        {selectedReport === "Placeholder" && <PlaceholderPage />}
+      </div>
+    </div>
+  );
+}

--- a/src/app/datamining/placeholder/page.tsx
+++ b/src/app/datamining/placeholder/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function PlaceholderPage() {
+  return (
+    <div className="p-6 text-gray-400">
+      🚧 Em breve: novos relatórios aqui...
+    </div>
+  );
+}

--- a/src/app/sidebar.tsx
+++ b/src/app/sidebar.tsx
@@ -64,7 +64,7 @@ export default function Sidebar() {
         {[
           { href: "/", icon: LayoutDashboard, label: "Home" },
           { href: "/database", icon: Database, label: "Database" },
-          { href: "/reports", icon: BarChart3, label: "Reports" },
+          { href: "/datamining", icon: BarChart3, label: "Data Mining" },
           { href: "/warnings", icon: AlertTriangle, label: "Database Warning" },
           { href: "/jrpedia", icon: BookOpenText, label: "JRpedia" },
         ].map(({ href, icon: Icon, label }) => {


### PR DESCRIPTION
## Summary
- rename the global Reports navigation entry to Data Mining
- move the existing reports experience under /datamining with an internal sidebar
- add a placeholder route for future Data Mining content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dad9c252fc832a8364d9677b2b6e8a