### PR TITLE
Update datamining layout

### DIFF
--- a/src/app/datamining/components/Sidebar.tsx
+++ b/src/app/datamining/components/Sidebar.tsx
@@ -9,9 +9,9 @@ export default function Sidebar({ selectedReport, setSelectedReport }: SidebarPr
   const reports = ["Bulletins", "Placeholder"];
 
   return (
-    <div className="w-64 bg-[#1e2a38] text-white h-full p-4">
+    <div className="h-full flex flex-col">
       <h2 className="text-lg font-bold mb-4">Data Mining</h2>
-      <ul>
+      <ul className="flex-1 space-y-1">
         {reports.map((r) => (
           <li key={r}>
             <button

--- a/src/app/datamining/page.tsx
+++ b/src/app/datamining/page.tsx
@@ -10,8 +10,13 @@ export default function DataMiningPage() {
 
   return (
     <div className="flex h-screen">
-      <Sidebar selectedReport={selectedReport} setSelectedReport={setSelectedReport} />
-      <div className="flex-1 overflow-y-auto">
+      {/* Sidebar interno */}
+      <div className="w-72 bg-[#1e2a38] text-white border-r border-gray-700">
+        <Sidebar selectedReport={selectedReport} setSelectedReport={setSelectedReport} />
+      </div>
+
+      {/* Painel principal */}
+      <div className="flex-1 bg-[#0f172a] text-white p-6">
         {selectedReport === "Bulletins" && <BulletinsPage />}
         {selectedReport === "Placeholder" && <PlaceholderPage />}
       </div>


### PR DESCRIPTION
## Summary
- wrap the data mining sidebar in a styled container to match JRpedia layout
- adjust the main content area styling for the datamining page
- align the sidebar component structure with the new container expectations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dadddb7588832ab26f873e19b62cb9