### PR TITLE
Align Data Mining sidebar styling with JRpedia

### DIFF
--- a/src/app/datamining/components/Sidebar.tsx
+++ b/src/app/datamining/components/Sidebar.tsx
@@ -9,14 +9,14 @@ export default function Sidebar({ selectedReport, setSelectedReport }: SidebarPr
   const reports = ["Bulletins", "Placeholder"];
 
   return (
-    <div className="w-64 bg-[#1e2a38] text-white h-full p-4">
-      <h2 className="text-lg font-bold mb-4">Data Mining</h2>
-      <ul>
+    <div className="flex h-full flex-col">
+      <h2 className="mb-4 px-3 text-lg font-bold">Data Mining</h2>
+      <ul className="flex-1 space-y-1 px-2">
         {reports.map((r) => (
           <li key={r}>
             <button
               onClick={() => setSelectedReport(r)}
-              className={`block w-full text-left px-2 py-1 rounded ${
+              className={`block w-full rounded px-2 py-1 text-left ${
                 selectedReport === r ? "bg-[#d4af37] text-black" : "hover:bg-[#2e3b4a]"
               }`}
             >

--- a/src/app/datamining/page.tsx
+++ b/src/app/datamining/page.tsx
@@ -10,8 +10,12 @@ export default function DataMiningPage() {
 
   return (
     <div className="flex h-screen">
-      <Sidebar selectedReport={selectedReport} setSelectedReport={setSelectedReport} />
-      <div className="flex-1 overflow-y-auto">
+      <aside
+        className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm"
+      >
+        <Sidebar selectedReport={selectedReport} setSelectedReport={setSelectedReport} />
+      </aside>
+      <div className="ml-2 flex-1 overflow-y-auto rounded-md border border-gray-200 bg-white p-6 text-black">
         {selectedReport === "Bulletins" && <BulletinsPage />}
         {selectedReport === "Placeholder" && <PlaceholderPage />}
       </div>


### PR DESCRIPTION
## Summary
- wrap the Data Mining sidebar with the same adjustable panel styling used in JRpedia
- add bordering and spacing to the main Data Mining content pane to mirror JRpedia
- simplify the Data Mining sidebar component so layout styling comes from the page container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae0e749d8832a8477bb2b4350405f