### PR TITLE
Add static Data Mining report tree and recursive sidebar

### DIFF
--- a/src/app/datamining/components/Sidebar.tsx
+++ b/src/app/datamining/components/Sidebar.tsx
@@ -1,28 +1,70 @@
 "use client";
 
+import { useState } from "react";
+import { reportTree, ReportNode } from "../dataTree";
+
 type SidebarProps = {
   selectedReport: string | null;
   setSelectedReport: (report: string) => void;
 };
 
-export default function Sidebar({ selectedReport, setSelectedReport }: SidebarProps) {
-  const reports = ["Bulletins", "Placeholder"];
+function Node({
+  node,
+  selectedReport,
+  setSelectedReport,
+}: {
+  node: ReportNode;
+  selectedReport: string | null;
+  setSelectedReport: (id: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
 
+  const hasChildren = node.children && node.children.length > 0;
+
+  return (
+    <li>
+      <div
+        className={`flex items-center justify-between px-2 py-1 rounded cursor-pointer ${
+          selectedReport === node.id
+            ? "bg-[#d4af37] text-black"
+            : "hover:bg-[#2e3b4a] text-white"
+        }`}
+        onClick={() => {
+          if (!hasChildren) setSelectedReport(node.id);
+          else setExpanded(!expanded);
+        }}
+      >
+        <span>{node.name}</span>
+        {hasChildren && <span>{expanded ? "▾" : "▸"}</span>}
+      </div>
+      {hasChildren && expanded && (
+        <ul className="ml-4 space-y-1">
+          {node.children!.map((child) => (
+            <Node
+              key={child.id}
+              node={child}
+              selectedReport={selectedReport}
+              setSelectedReport={setSelectedReport}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function Sidebar({ selectedReport, setSelectedReport }: SidebarProps) {
   return (
     <div className="flex h-full flex-col">
       <h2 className="mb-4 px-3 text-lg font-bold">Data Mining</h2>
-      <ul className="flex-1 space-y-1 px-2">
-        {reports.map((r) => (
-          <li key={r}>
-            <button
-              onClick={() => setSelectedReport(r)}
-              className={`block w-full rounded px-2 py-1 text-left ${
-                selectedReport === r ? "bg-[#d4af37] text-black" : "hover:bg-[#2e3b4a]"
-              }`}
-            >
-              {r}
-            </button>
-          </li>
+      <ul className="flex-1 space-y-2 px-2">
+        {reportTree.map((node) => (
+          <Node
+            key={node.id}
+            node={node}
+            selectedReport={selectedReport}
+            setSelectedReport={setSelectedReport}
+          />
         ))}
       </ul>
     </div>

--- a/src/app/datamining/dataTree.ts
+++ b/src/app/datamining/dataTree.ts
@@ -1,0 +1,17 @@
+export type ReportNode = {
+  id: string;
+  name: string;
+  children?: ReportNode[];
+};
+
+export const reportTree: ReportNode[] = [
+  {
+    id: "bulletins",
+    name: "Bulletins",
+    children: [
+      { id: "storytelling", name: "Storytelling" },
+      { id: "sandbox", name: "Sandbox" },
+    ],
+  },
+  { id: "placeholder", name: "Placeholder" },
+];

--- a/src/app/datamining/page.tsx
+++ b/src/app/datamining/page.tsx
@@ -2,22 +2,24 @@
 
 import { useState } from "react";
 import Sidebar from "./components/Sidebar";
-import BulletinsPage from "./bulletins/page";
+import StorytellingPage from "./bulletins/page";
+import SandboxBulletinsPage from "../sandbox/bulletins/page";
 import PlaceholderPage from "./placeholder/page";
 
 export default function DataMiningPage() {
-  const [selectedReport, setSelectedReport] = useState<string>("Bulletins");
+  const [selectedReport, setSelectedReport] = useState<string>("storytelling");
 
   return (
     <div className="flex h-screen">
       <aside
-        className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm"
+        className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-200 bg-[#1e2a38] text-white shadow-sm"
       >
         <Sidebar selectedReport={selectedReport} setSelectedReport={setSelectedReport} />
       </aside>
       <div className="ml-2 flex-1 overflow-y-auto rounded-md border border-gray-200 bg-white p-6 text-black">
-        {selectedReport === "Bulletins" && <BulletinsPage />}
-        {selectedReport === "Placeholder" && <PlaceholderPage />}
+        {selectedReport === "storytelling" && <StorytellingPage />}
+        {selectedReport === "sandbox" && <SandboxBulletinsPage />}
+        {selectedReport === "placeholder" && <PlaceholderPage />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a static report tree definition for Data Mining reports
- rebuild the Data Mining sidebar to render the tree with expandable nodes
- update the main Data Mining page to map selections to the storytelling, sandbox, and placeholder views

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae97e69bc832abeab922468553a64