### PR TITLE
Refactor Data Mining sidebar to use report tree

### DIFF
--- a/src/app/datamining/components/Sidebar.tsx
+++ b/src/app/datamining/components/Sidebar.tsx
@@ -1,56 +1,76 @@
 "use client";
 
+import { useState } from "react";
+import { reportTree, ReportNode } from "../dataTree";
+
 type SidebarProps = {
   selectedReport: string | null;
   setSelectedReport: (report: string) => void;
 };
 
-export default function Sidebar({ selectedReport, setSelectedReport }: SidebarProps) {
-  const sections = [
-    {
-      name: "Bulletins",
-      children: ["Storytelling", "Sandbox"],
-    },
-    { name: "Placeholder", children: [] },
-  ];
+// Nó recursivo da árvore, inspirado no JRpedia
+// Controla seleção e expand/collapse
+function Node({
+  node,
+  selectedReport,
+  setSelectedReport,
+}: {
+  node: ReportNode;
+  selectedReport: string | null;
+  setSelectedReport: (report: string) => void;
+}) {
+  const hasChildren = node.children && node.children.length > 0;
+  const [isOpen, setIsOpen] = useState(hasChildren ? node.defaultExpanded ?? false : false);
+  const isSelected = selectedReport === node.id;
 
+  const handleClick = () => {
+    if (hasChildren) {
+      setIsOpen((prev) => !prev);
+    } else {
+      setSelectedReport(node.id);
+    }
+  };
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={handleClick}
+        className={`flex w-full items-center gap-2 rounded px-2 py-1 text-left transition-colors ${
+          isSelected ? "bg-[#d4af37] text-black" : "hover:bg-[#2e3b4a] text-white"
+        } ${hasChildren ? "font-semibold" : ""}`}
+      >
+        {hasChildren && <span className="text-xs">{isOpen ? "▾" : "▸"}</span>}
+        <span>{node.label}</span>
+      </button>
+      {hasChildren && isOpen && (
+        <ul className="ml-4 space-y-1 border-l border-gray-700 pl-2">
+          {node.children!.map((child) => (
+            <Node
+              key={child.id}
+              node={child}
+              selectedReport={selectedReport}
+              setSelectedReport={setSelectedReport}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function Sidebar({ selectedReport, setSelectedReport }: SidebarProps) {
   return (
     <div className="flex h-full flex-col">
       <h2 className="mb-4 px-3 text-lg font-bold">Data Mining</h2>
       <ul className="flex-1 space-y-2 px-2">
-        {sections.map((section) => (
-          <li key={section.name}>
-            <div className="font-semibold mb-1">{section.name}</div>
-            {section.children.length > 0 ? (
-              <ul className="ml-4 space-y-1">
-                {section.children.map((child) => (
-                  <li key={child}>
-                    <button
-                      onClick={() => setSelectedReport(child)}
-                      className={`block w-full rounded px-2 py-1 text-left ${
-                        selectedReport === child
-                          ? "bg-[#d4af37] text-black"
-                          : "hover:bg-[#2e3b4a] text-white"
-                      }`}
-                    >
-                      {child}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <button
-                onClick={() => setSelectedReport(section.name)}
-                className={`block w-full rounded px-2 py-1 text-left ${
-                  selectedReport === section.name
-                    ? "bg-[#d4af37] text-black"
-                    : "hover:bg-[#2e3b4a] text-white"
-                }`}
-              >
-                {section.name}
-              </button>
-            )}
-          </li>
+        {reportTree.map((node) => (
+          <Node
+            key={node.id}
+            node={node}
+            selectedReport={selectedReport}
+            setSelectedReport={setSelectedReport}
+          />
         ))}
       </ul>
     </div>

--- a/src/app/datamining/dataTree.ts
+++ b/src/app/datamining/dataTree.ts
@@ -1,0 +1,22 @@
+export type ReportNode = {
+  id: string;
+  label: string;
+  children?: ReportNode[];
+  defaultExpanded?: boolean;
+};
+
+export const reportTree: ReportNode[] = [
+  {
+    id: "bulletins",
+    label: "Boletins",
+    defaultExpanded: true,
+    children: [
+      { id: "storytelling", label: "Storytelling" },
+      { id: "sandbox", label: "Sandbox" },
+    ],
+  },
+  {
+    id: "placeholder",
+    label: "Placeholder",
+  },
+];

--- a/src/app/datamining/page.tsx
+++ b/src/app/datamining/page.tsx
@@ -7,19 +7,19 @@ import SandboxBulletinsPage from "./bulletins/sandbox/page";
 import PlaceholderPage from "./placeholder/page";
 
 export default function DataMiningPage() {
-  const [selectedReport, setSelectedReport] = useState<string>("Storytelling");
+  const [selectedReport, setSelectedReport] = useState<string>("storytelling");
 
   return (
     <div className="flex h-screen">
       <aside
-        className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm"
+        className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-200 bg-[#1e2a38] text-white shadow-sm"
       >
         <Sidebar selectedReport={selectedReport} setSelectedReport={setSelectedReport} />
       </aside>
       <div className="ml-2 flex-1 overflow-y-auto rounded-md border border-gray-200 bg-white p-6 text-black">
-        {selectedReport === "Storytelling" && <StorytellingPage />}
-        {selectedReport === "Sandbox" && <SandboxBulletinsPage />}
-        {selectedReport === "Placeholder" && <PlaceholderPage />}
+        {selectedReport === "storytelling" && <StorytellingPage />}
+        {selectedReport === "sandbox" && <SandboxBulletinsPage />}
+        {selectedReport === "placeholder" && <PlaceholderPage />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- introduce a reusable report tree definition for the Data Mining area
- refactor the sidebar to render a collapsible tree based on the report nodes
- align the Data Mining page with the new report identifiers and sandbox path

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daee64e220832a82c28b1d702b07fd