### PR TITLE
Refine data mining sidebar tree

### DIFF
--- a/src/app/datamining/components/Sidebar.tsx
+++ b/src/app/datamining/components/Sidebar.tsx
@@ -1,32 +1,24 @@
 "use client";
 
-import { useState } from "react";
-import { reportTree, ReportNode } from "../dataTree";
+import { reportTree, type ReportNode } from "../dataTree";
 
 type SidebarProps = {
   selectedReport: string | null;
   setSelectedReport: (report: string) => void;
 };
 
-// Nó recursivo da árvore, inspirado no JRpedia
-// Controla seleção e expand/collapse
-function Node({
-  node,
-  selectedReport,
-  setSelectedReport,
-}: {
+type NodeProps = {
   node: ReportNode;
   selectedReport: string | null;
-  setSelectedReport: (report: string) => void;
-}) {
-  const hasChildren = node.children && node.children.length > 0;
-  const [isOpen, setIsOpen] = useState(hasChildren ? node.defaultExpanded ?? false : false);
+  setSelectedReport: (id: string) => void;
+};
+
+function TreeNode({ node, selectedReport, setSelectedReport }: NodeProps) {
+  const hasChildren = !!(node.children && node.children.length > 0);
   const isSelected = selectedReport === node.id;
 
   const handleClick = () => {
-    if (hasChildren) {
-      setIsOpen((prev) => !prev);
-    } else {
+    if (!hasChildren) {
       setSelectedReport(node.id);
     }
   };
@@ -36,17 +28,16 @@ function Node({
       <button
         type="button"
         onClick={handleClick}
-        className={`flex w-full items-center gap-2 rounded px-2 py-1 text-left transition-colors ${
-          isSelected ? "bg-[#d4af37] text-black" : "hover:bg-[#2e3b4a] text-white"
-        } ${hasChildren ? "font-semibold" : ""}`}
+        className={`w-full rounded px-2 py-1 text-left transition-colors ${
+          isSelected ? "bg-[#d4af37] text-black" : "text-white hover:bg-[#2e3b4a]"
+        }`}
       >
-        {hasChildren && <span className="text-xs">{isOpen ? "▾" : "▸"}</span>}
-        <span>{node.label}</span>
+        {node.label}
       </button>
-      {hasChildren && isOpen && (
+      {hasChildren && (
         <ul className="ml-4 space-y-1 border-l border-gray-700 pl-2">
           {node.children!.map((child) => (
-            <Node
+            <TreeNode
               key={child.id}
               node={child}
               selectedReport={selectedReport}
@@ -63,16 +54,18 @@ export default function Sidebar({ selectedReport, setSelectedReport }: SidebarPr
   return (
     <div className="flex h-full flex-col">
       <h2 className="mb-4 px-3 text-lg font-bold">Data Mining</h2>
-      <ul className="flex-1 space-y-2 px-2">
-        {reportTree.map((node) => (
-          <Node
-            key={node.id}
-            node={node}
-            selectedReport={selectedReport}
-            setSelectedReport={setSelectedReport}
-          />
-        ))}
-      </ul>
+      <div className="flex-1 overflow-y-auto px-2">
+        <ul className="space-y-1">
+          {reportTree.map((node) => (
+            <TreeNode
+              key={node.id}
+              node={node}
+              selectedReport={selectedReport}
+              setSelectedReport={setSelectedReport}
+            />
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/src/app/datamining/dataTree.ts
+++ b/src/app/datamining/dataTree.ts
@@ -8,8 +8,7 @@ export type ReportNode = {
 export const reportTree: ReportNode[] = [
   {
     id: "bulletins",
-    label: "Boletins",
-    defaultExpanded: true,
+    label: "Bulletins",
     children: [
       { id: "storytelling", label: "Storytelling" },
       { id: "sandbox", label: "Sandbox" },


### PR DESCRIPTION
## Summary
- replace the recursive sidebar node with a simplified tree component that always expands children and highlights the selected report
- wrap the tree list with a scroll container to improve navigation on long lists
- update the data tree labels to use English naming

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daf2fd9a6c832a9021f1ca26c0dc01