### PR TITLE
Add Novas Empresas placeholder report

### DIFF
--- a/src/app/datamining/dataTree.ts
+++ b/src/app/datamining/dataTree.ts
@@ -17,5 +17,8 @@ export const reportTree: ReportNode[] = [
   {
     id: "placeholder",
     label: "Placeholder",
+    children: [
+      { id: "new-listings", label: "Novas Empresas" },
+    ],
   },
 ];

--- a/src/app/datamining/page.tsx
+++ b/src/app/datamining/page.tsx
@@ -5,6 +5,7 @@ import Sidebar from "./components/Sidebar";
 import StorytellingPage from "./bulletins/page";
 import SandboxBulletinsPage from "./bulletins/sandbox/page";
 import PlaceholderPage from "./placeholder/page";
+import NewListingsPage from "./placeholder/new-listings";
 
 export default function DataMiningPage() {
   const [selectedReport, setSelectedReport] = useState<string>("storytelling");
@@ -20,6 +21,7 @@ export default function DataMiningPage() {
         {selectedReport === "storytelling" && <StorytellingPage />}
         {selectedReport === "sandbox" && <SandboxBulletinsPage />}
         {selectedReport === "placeholder" && <PlaceholderPage />}
+        {selectedReport === "new-listings" && <NewListingsPage />}
       </div>
     </div>
   );

--- a/src/app/datamining/placeholder/new-listings.tsx
+++ b/src/app/datamining/placeholder/new-listings.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@supabase/supabase-js";
+import {
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  CartesianGrid,
+} from "recharts";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+);
+
+interface Row {
+  id: number;
+  company: string | null;
+  ticker: string | null;
+  bulletin_date: string | null;
+  canonical_type: string | null;
+}
+
+export default function NewListingsPage() {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const { data, error } = await supabase
+        .from("bulletins")
+        .select("id, company, ticker, bulletin_date, canonical_type")
+        .in("canonical_type", [
+          "NEW LISTING - IPO - SHARES",
+          "NEW LISTING - CPC - SHARES",
+        ])
+        .order("bulletin_date", { ascending: true });
+
+      if (error) console.error(error);
+      else setRows(data || []);
+      setLoading(false);
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) return <div>⏳ Carregando...</div>;
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Novas Empresas (TSXV)</h2>
+      <ResponsiveContainer width="100%" height={500}>
+        <ScatterChart>
+          <CartesianGrid />
+          <XAxis dataKey="bulletin_date" name="Data" />
+          <YAxis dataKey="company" name="Empresa" type="category" />
+          <Tooltip cursor={{ strokeDasharray: "3 3" }} />
+          <Legend />
+          <Scatter name="Nova Listagem" data={rows} fill="#d4af37" />
+        </ScatterChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add the "Novas Empresas" report to the data mining navigation tree
- implement the new listings scatter chart that filters bulletin data to IPO and CPC listings
- render the new report when selected within the data mining dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db09fa480c832a94ccc4b834831baf