### PR TITLE
Refine data mining navigation

### DIFF
--- a/src/app/datamining/bulletins/canonical-map.tsx
+++ b/src/app/datamining/bulletins/canonical-map.tsx
@@ -1,0 +1,1 @@
+export { default } from "./sandbox/page";

--- a/src/app/datamining/bulletins/page.tsx
+++ b/src/app/datamining/bulletins/page.tsx
@@ -33,7 +33,7 @@ type Row = {
 
 type Option = { value: string; label: string }
 
-export default function BulletinsPage() {
+export default function NoticesPage() {
   const [rows, setRows] = useState<Row[]>([])
   const [loading, setLoading] = useState(true)
   const [selectedCompanies, setSelectedCompanies] = useState<string[]>([])
@@ -178,7 +178,7 @@ export default function BulletinsPage() {
     <div className="p-6">
       {/* Topo com export */}
       <div className="flex items-center justify-between mb-4 gap-4">
-        <h1 className="text-2xl font-bold">TSXV 2008 — Storytelling por Empresa</h1>
+        <h1 className="text-2xl font-bold">Notices — TSXV 2008</h1>
         <div className="flex gap-2">
           <button
             onClick={() => handleDownload('zip')}

--- a/src/app/datamining/bulletins/sandbox/page.tsx
+++ b/src/app/datamining/bulletins/sandbox/page.tsx
@@ -35,7 +35,7 @@ type DataItem = {
   percent: number;
 };
 
-export default function BulletinsPage() {
+export default function CanonicalMapPage() {
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [chartData, setChartData] = useState<DataItem[]>([]);
@@ -135,7 +135,7 @@ export default function BulletinsPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-1">Bulletins</h1>
+      <h1 className="text-2xl font-bold mb-1">Canonical Map</h1>
       <p className="text-gray-500 mb-6">
         Distribuição de tipos de boletim (Canonical) — Scatter + Pareto
       </p>

--- a/src/app/datamining/dataTree.ts
+++ b/src/app/datamining/dataTree.ts
@@ -10,15 +10,15 @@ export const reportTree: ReportNode[] = [
     id: "bulletins",
     label: "Bulletins",
     children: [
-      { id: "storytelling", label: "Storytelling" },
-      { id: "sandbox", label: "Sandbox" },
+      { id: "notices", label: "Notices" },
+      { id: "canonical-map", label: "Canonical Map" },
     ],
   },
   {
-    id: "placeholder",
-    label: "Placeholder",
+    id: "lifecycle",
+    label: "Lifecycle",
     children: [
-      { id: "new-listings", label: "Novas Empresas" },
+      { id: "new-listings", label: "New Listings" },
     ],
   },
 ];

--- a/src/app/datamining/page.tsx
+++ b/src/app/datamining/page.tsx
@@ -2,13 +2,12 @@
 
 import { useState } from "react";
 import Sidebar from "./components/Sidebar";
-import StorytellingPage from "./bulletins/page";
-import SandboxBulletinsPage from "./bulletins/sandbox/page";
-import PlaceholderPage from "./placeholder/page";
+import NoticesPage from "./bulletins/page";
+import CanonicalMapPage from "./bulletins/canonical-map";
 import NewListingsPage from "./placeholder/new-listings";
 
 export default function DataMiningPage() {
-  const [selectedReport, setSelectedReport] = useState<string>("storytelling");
+  const [selectedReport, setSelectedReport] = useState<string>("notices");
 
   return (
     <div className="flex h-screen">
@@ -18,9 +17,8 @@ export default function DataMiningPage() {
         <Sidebar selectedReport={selectedReport} setSelectedReport={setSelectedReport} />
       </aside>
       <div className="ml-2 flex-1 overflow-y-auto rounded-md border border-gray-200 bg-white p-6 text-black">
-        {selectedReport === "storytelling" && <StorytellingPage />}
-        {selectedReport === "sandbox" && <SandboxBulletinsPage />}
-        {selectedReport === "placeholder" && <PlaceholderPage />}
+        {selectedReport === "notices" && <NoticesPage />}
+        {selectedReport === "canonical-map" && <CanonicalMapPage />}
         {selectedReport === "new-listings" && <NewListingsPage />}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- reorganize the data mining navigation tree to highlight bulletins and lifecycle sections
- retitle the bulletins content to "Notices" and surface the canonical map visualization directly
- wire the new navigation items to the appropriate content pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db10f851a0832aaeb5aaaa555801ff