### PR TITLE
Add date and type filters to TSXV new listings view

### DIFF
--- a/src/app/datamining/lifecycle/new-listings/page.tsx
+++ b/src/app/datamining/lifecycle/new-listings/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { createClient } from "@supabase/supabase-js";
-import Select, { MultiValue } from "react-select";
 import {
   ResponsiveContainer,
   ScatterChart,
@@ -27,18 +26,18 @@ type Row = {
   canonical_type: string | null;
 };
 
-type Option = { value: string; label: string };
-
 export default function NewListingsPage() {
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<string[]>([
     "NEW LISTING - IPO - SHARES",
     "NEW LISTING - CPC - SHARES",
     "NEW LISTING - SHARES",
   ]);
 
-  const typeOptions: Option[] = [
+  const typeOptions: { value: string; label: string }[] = [
     { value: "NEW LISTING - IPO - SHARES", label: "IPO" },
     { value: "NEW LISTING - CPC - SHARES", label: "CPC" },
     { value: "NEW LISTING - SHARES", label: "Shares" },
@@ -47,35 +46,73 @@ export default function NewListingsPage() {
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
-      const { data, error } = await supabase
-        .from("bulletins")
+      let query = supabase
+        .from("vw_bulletins_with_canonical")
         .select("id, company, ticker, bulletin_date, canonical_type")
-        .in("canonical_type", selectedTypes)
-        .order("bulletin_date", { ascending: true });
+        .in("canonical_type", selectedTypes);
 
-      if (error) console.error(error);
-      else setRows(data || []);
+      if (startDate) query = query.gte("bulletin_date", startDate);
+      if (endDate) query = query.lte("bulletin_date", endDate);
+
+      const { data, error } = await query.order("bulletin_date", { ascending: true });
+
+      if (error) {
+        console.error("Erro Supabase:", error.message);
+        setRows([]);
+      } else {
+        setRows(data || []);
+      }
       setLoading(false);
     };
 
     fetchData();
-  }, [selectedTypes]);
+  }, [selectedTypes, startDate, endDate]);
 
   return (
     <div className="p-6">
       <h2 className="text-xl font-bold mb-4">New Listings (TSXV)</h2>
 
-      {/* Filtro de tipos */}
-      <div className="mb-4">
-        <label className="block text-sm font-medium mb-1">Filtrar por tipo</label>
-        <Select
-          isMulti
-          options={typeOptions}
-          value={typeOptions.filter(opt => selectedTypes.includes(opt.value))}
-          onChange={(vals: MultiValue<Option>) =>
-            setSelectedTypes(vals.map(v => v.value))
-          }
-        />
+      {/* Filtros */}
+      <div className="flex flex-wrap gap-6 mb-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Start Date</label>
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="border rounded px-2 py-1"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">End Date</label>
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            className="border rounded px-2 py-1"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Tipos de Boletim</label>
+          {typeOptions.map((opt) => (
+            <div key={opt.value} className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                id={opt.value}
+                checked={selectedTypes.includes(opt.value)}
+                onChange={() => {
+                  setSelectedTypes((prev) =>
+                    prev.includes(opt.value)
+                      ? prev.filter((t) => t !== opt.value)
+                      : [...prev, opt.value]
+                  );
+                }}
+                className="h-4 w-4"
+              />
+              <label htmlFor={opt.value}>{opt.label}</label>
+            </div>
+          ))}
+        </div>
       </div>
 
       {loading ? (


### PR DESCRIPTION
## Summary
- add date inputs and checkbox filters to the TSXV new listings page
- update Supabase query to use the canonical view and handle errors gracefully

## Testing
- npm run dev *(fails locally: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68db24df04f8832ab74366338d39985e