### PR TITLE
Improve new listings filters and display

### DIFF
--- a/src/app/datamining/lifecycle/new-listings/page.tsx
+++ b/src/app/datamining/lifecycle/new-listings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { createClient } from "@supabase/supabase-js";
+import Select, { MultiValue } from "react-select";
 import {
   ResponsiveContainer,
   ScatterChart,
@@ -20,53 +21,86 @@ const supabase = createClient(
 
 type Row = {
   id: number;
+  source_file: string | null;
   company: string | null;
   ticker: string | null;
-  bulletin_date: string | null;
+  listing_date: string | null;
+  body_text: string | null;
   canonical_type: string | null;
 };
+
+type Option = { value: string; label: string };
 
 export default function NewListingsPage() {
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selectedCompanies, setSelectedCompanies] = useState<string[]>([]);
+  const [selectedTypes, setSelectedTypes] = useState<string[]>([
+    "NEW LISTING-IPO-SHARES",
+    "NEW LISTING-CPC-SHARES",
+    "NEW LISTING-SHARES",
+  ]);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
-  const [selectedTypes, setSelectedTypes] = useState<string[]>([
-    "NEW LISTING - IPO - SHARES",
-    "NEW LISTING - CPC - SHARES",
-    "NEW LISTING - SHARES",
-  ]);
+  const [globalMin, setGlobalMin] = useState("");
+  const [globalMax, setGlobalMax] = useState("");
 
-  const typeOptions: { value: string; label: string }[] = [
+  const typeOptions: Option[] = [
     { value: "NEW LISTING-IPO-SHARES", label: "IPO" },
     { value: "NEW LISTING-CPC-SHARES", label: "CPC" },
     { value: "NEW LISTING-SHARES", label: "Shares" },
   ];
 
   useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      let query = supabase
-        .from("vw_bulletins_with_canonical")
-        .select("id, company, ticker, bulletin_date, canonical_type")
-        .in("canonical_type", selectedTypes);
+    async function fetchData() {
+      try {
+        const { data } = await supabase
+          .from("vw_new_listings")
+          .select(
+            "id, source_file, company, ticker, listing_date, body_text, canonical_type",
+          )
+          .throwOnError();
 
-      if (startDate) query = query.gte("bulletin_date", startDate);
-      if (endDate) query = query.lte("bulletin_date", endDate);
-
-      const { data, error } = await query.order("bulletin_date", { ascending: true });
-
-      if (error) {
-        console.error("Erro Supabase:", error.message);
+        if (data) {
+          setRows(data as Row[]);
+          const dates = data.map((r) => r.listing_date).filter(Boolean) as string[];
+          if (dates.length) {
+            const minDate = dates.reduce((a, b) => (a < b ? a : b));
+            const maxDate = dates.reduce((a, b) => (a > b ? a : b));
+            setStartDate(minDate);
+            setEndDate(maxDate);
+            setGlobalMin(minDate);
+            setGlobalMax(maxDate);
+          }
+        }
+      } catch (error) {
+        console.error("Erro ao carregar novas listagens:", error);
         setRows([]);
-      } else {
-        setRows(data || []);
+      } finally {
+        setLoading(false);
       }
-      setLoading(false);
-    };
-
+    }
     fetchData();
-  }, [selectedTypes, startDate, endDate]);
+  }, []);
+
+  const filteredRows = rows.filter((r) => {
+    const companyOk =
+      selectedCompanies.length === 0 ? true : selectedCompanies.includes(r.company ?? "");
+    const typeOk =
+      selectedTypes.length === 0 ? true : selectedTypes.includes(r.canonical_type ?? "");
+    const dateOk = r.listing_date
+      ? (!startDate || r.listing_date >= startDate) && (!endDate || r.listing_date <= endDate)
+      : false;
+    return companyOk && typeOk && dateOk;
+  });
+
+  const companyOptions: Option[] = Array.from(
+    new Set(rows.map((r) => r.company).filter(Boolean)),
+  ).map((c) => ({ value: c!, label: c! }));
+
+  function handleCompanyChange(selected: MultiValue<Option>) {
+    setSelectedCompanies(selected.map((s) => s.value));
+  }
 
   return (
     <div className="p-6">
@@ -79,6 +113,8 @@ export default function NewListingsPage() {
           <input
             type="date"
             value={startDate}
+            min={globalMin}
+            max={endDate || globalMax}
             onChange={(e) => setStartDate(e.target.value)}
             className="border rounded px-2 py-1"
           />
@@ -88,8 +124,19 @@ export default function NewListingsPage() {
           <input
             type="date"
             value={endDate}
+            min={startDate || globalMin}
+            max={globalMax}
             onChange={(e) => setEndDate(e.target.value)}
             className="border rounded px-2 py-1"
+          />
+        </div>
+        <div className="min-w-[240px] flex-1">
+          <label className="block text-sm font-medium">Companies</label>
+          <Select
+            isMulti
+            options={companyOptions}
+            value={companyOptions.filter((option) => selectedCompanies.includes(option.value))}
+            onChange={handleCompanyChange}
           />
         </div>
         <div>
@@ -104,7 +151,7 @@ export default function NewListingsPage() {
                   setSelectedTypes((prev) =>
                     prev.includes(opt.value)
                       ? prev.filter((t) => t !== opt.value)
-                      : [...prev, opt.value]
+                      : [...prev, opt.value],
                   );
                 }}
                 className="h-4 w-4"
@@ -122,18 +169,18 @@ export default function NewListingsPage() {
           <ResponsiveContainer width="100%" height={500}>
             <ScatterChart>
               <CartesianGrid />
-              <XAxis dataKey="bulletin_date" name="Data" />
-              <YAxis dataKey="company" name="Empresa" type="category" />
+              <XAxis dataKey="listing_date" name="Date" type="category" />
+              <YAxis dataKey="ticker" name="Ticker" type="category" />
               <Tooltip cursor={{ strokeDasharray: "3 3" }} />
               <Legend />
-              <Scatter name="Nova Listagem" data={rows} fill="#d4af37" />
+              <Scatter name="Nova Listagem" data={filteredRows} fill="#d4af37" />
             </ScatterChart>
           </ResponsiveContainer>
 
           {/* Tabela de resultados */}
           <div className="mt-6 border rounded-lg p-4 bg-gray-50">
             <h2 className="text-lg font-semibold mb-2">Resultados</h2>
-            {rows.length === 0 ? (
+            {filteredRows.length === 0 ? (
               <p className="text-gray-400">Nenhuma empresa encontrada no filtro.</p>
             ) : (
               <table className="w-full text-sm border">
@@ -146,11 +193,11 @@ export default function NewListingsPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {rows.map((row) => (
+                  {filteredRows.map((row) => (
                     <tr key={row.id} className="hover:bg-gray-100">
                       <td className="border px-2 py-1">{row.company}</td>
                       <td className="border px-2 py-1">{row.ticker}</td>
-                      <td className="border px-2 py-1">{row.bulletin_date}</td>
+                      <td className="border px-2 py-1">{row.listing_date}</td>
                       <td className="border px-2 py-1">{row.canonical_type}</td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary
- load all new listing records once from Supabase and derive global date bounds
- add company multi-select and persistent type checkboxes with client-side filtering
- show filtered scatter plot and table results using listing dates and tickers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db38a27d88832ab924d3a75823cd22