### PR TITLE
Add date range filter logic to new listings page

### DIFF
--- a/src/app/datamining/lifecycle/new-listings/page.tsx
+++ b/src/app/datamining/lifecycle/new-listings/page.tsx
@@ -29,8 +29,10 @@ type Row = {
 export default function NewListingsPage() {
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
+  const [listingStartDate, setListingStartDate] = useState("");
+  const [listingEndDate, setListingEndDate] = useState("");
+  const [globalMinDate, setGlobalMinDate] = useState("");
+  const [globalMaxDate, setGlobalMaxDate] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<string[]>([
     "NEW LISTING - IPO - SHARES",
     "NEW LISTING - CPC - SHARES",
@@ -44,29 +46,73 @@ export default function NewListingsPage() {
   ];
 
   useEffect(() => {
+    setListingStartDate("");
+    setListingEndDate("");
+  }, [selectedTypes]);
+
+  useEffect(() => {
     const fetchData = async () => {
+      if (selectedTypes.length === 0) {
+        setRows([]);
+        setGlobalMinDate("");
+        setGlobalMaxDate("");
+        setListingStartDate("");
+        setListingEndDate("");
+        setLoading(false);
+        return;
+      }
+
       setLoading(true);
-      let query = supabase
+      const { data, error } = await supabase
         .from("vw_bulletins_with_canonical")
         .select("id, company, ticker, bulletin_date, canonical_type")
-        .in("canonical_type", selectedTypes);
-
-      if (startDate) query = query.gte("bulletin_date", startDate);
-      if (endDate) query = query.lte("bulletin_date", endDate);
-
-      const { data, error } = await query.order("bulletin_date", { ascending: true });
+        .in("canonical_type", selectedTypes)
+        .order("bulletin_date", { ascending: true });
 
       if (error) {
         console.error("Erro Supabase:", error.message);
         setRows([]);
+        setGlobalMinDate("");
+        setGlobalMaxDate("");
       } else {
-        setRows(data || []);
+        const fetchedRows = (data || []) as Row[];
+        setRows(fetchedRows);
+        const dates = fetchedRows
+          .map((r) => r.bulletin_date)
+          .filter(Boolean) as string[];
+
+        if (dates.length > 0) {
+          const minDate = dates.reduce((a, b) => (a < b ? a : b));
+          const maxDate = dates.reduce((a, b) => (a > b ? a : b));
+          setGlobalMinDate(minDate);
+          setGlobalMaxDate(maxDate);
+          setListingStartDate((prev) => prev || minDate);
+          setListingEndDate((prev) => prev || maxDate);
+        } else {
+          setGlobalMinDate("");
+          setGlobalMaxDate("");
+          setListingStartDate("");
+          setListingEndDate("");
+        }
       }
       setLoading(false);
     };
 
     fetchData();
-  }, [selectedTypes, startDate, endDate]);
+  }, [selectedTypes]);
+
+  const filteredRows = rows.filter((row) => {
+    if (!row.bulletin_date) return false;
+    const withinStart =
+      !listingStartDate || row.bulletin_date >= listingStartDate;
+    const withinEnd = !listingEndDate || row.bulletin_date <= listingEndDate;
+    return withinStart && withinEnd;
+  });
+
+  const handleResetFilters = () => {
+    setListingStartDate(globalMinDate);
+    setListingEndDate(globalMaxDate);
+  };
 
   return (
     <div className="p-6">
@@ -78,8 +124,8 @@ export default function NewListingsPage() {
           <label className="block text-sm font-medium mb-1">Start Date</label>
           <input
             type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
+            value={listingStartDate}
+            onChange={(e) => setListingStartDate(e.target.value)}
             className="border rounded px-2 py-1"
           />
         </div>
@@ -87,10 +133,18 @@ export default function NewListingsPage() {
           <label className="block text-sm font-medium mb-1">End Date</label>
           <input
             type="date"
-            value={endDate}
-            onChange={(e) => setEndDate(e.target.value)}
+            value={listingEndDate}
+            onChange={(e) => setListingEndDate(e.target.value)}
             className="border rounded px-2 py-1"
           />
+        </div>
+        <div className="flex items-end">
+          <button
+            onClick={handleResetFilters}
+            className="px-3 py-1 bg-gray-200 text-black rounded hover:bg-gray-300"
+          >
+            🔄 Resetar filtros
+          </button>
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">Tipos de Boletim</label>
@@ -126,14 +180,14 @@ export default function NewListingsPage() {
               <YAxis dataKey="company" name="Empresa" type="category" />
               <Tooltip cursor={{ strokeDasharray: "3 3" }} />
               <Legend />
-              <Scatter name="Nova Listagem" data={rows} fill="#d4af37" />
+              <Scatter name="Nova Listagem" data={filteredRows} fill="#d4af37" />
             </ScatterChart>
           </ResponsiveContainer>
 
           {/* Tabela de resultados */}
           <div className="mt-6 border rounded-lg p-4 bg-gray-50">
             <h2 className="text-lg font-semibold mb-2">Resultados</h2>
-            {rows.length === 0 ? (
+            {filteredRows.length === 0 ? (
               <p className="text-gray-400">Nenhuma empresa encontrada no filtro.</p>
             ) : (
               <table className="w-full text-sm border">
@@ -146,7 +200,7 @@ export default function NewListingsPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {rows.map((row) => (
+                  {filteredRows.map((row) => (
                     <tr key={row.id} className="hover:bg-gray-100">
                       <td className="border px-2 py-1">{row.company}</td>
                       <td className="border px-2 py-1">{row.ticker}</td>


### PR DESCRIPTION
## Summary
- add lifecycle new listings date range state mirroring notices implementation
- compute global min/max listing dates from Supabase data and default filter inputs
- filter scatter chart and results table by the selected listing date range with reset option

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf65bd100832aaa8319cf44fcc968