### PR TITLE
Adjust chart spacing for new listings scatter plot

### DIFF
--- a/src/app/datamining/lifecycle/new-listings/page.tsx
+++ b/src/app/datamining/lifecycle/new-listings/page.tsx
@@ -233,7 +233,9 @@ export default function NewListingsPage() {
       ) : (
         <>
           <ResponsiveContainer width="100%" height={500}>
-            <ScatterChart>
+            <ScatterChart
+              margin={{ top: 20, right: 120, bottom: 20, left: 20 }}
+            >
               <CartesianGrid />
               <XAxis
                 type="number"
@@ -289,7 +291,11 @@ export default function NewListingsPage() {
                   return null;
                 }}
               />
-              <Legend verticalAlign="middle" align="right" />
+              <Legend
+                layout="vertical"
+                verticalAlign="top"
+                align="right"
+              />
               {scatterSeries.map((series) => (
                 <Scatter
                   key={series.canonical}


### PR DESCRIPTION
## Summary
- add outer margins to the new listings scatter chart for better spacing
- stack the legend vertically at the top right to avoid overlapping the plot

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68dc1a8fac00832a843178549cc193c5