### PR TITLE
Adjust legend spacing on new listings chart

### DIFF
--- a/src/app/datamining/lifecycle/new-listings/page.tsx
+++ b/src/app/datamining/lifecycle/new-listings/page.tsx
@@ -234,7 +234,7 @@ export default function NewListingsPage() {
         <>
           <ResponsiveContainer width="100%" height={500}>
             <ScatterChart
-              margin={{ top: 20, right: 120, bottom: 20, left: 20 }}
+              margin={{ top: 20, right: 160, bottom: 20, left: 20 }}
             >
               <CartesianGrid />
               <XAxis
@@ -295,6 +295,11 @@ export default function NewListingsPage() {
                 layout="vertical"
                 verticalAlign="top"
                 align="right"
+                wrapperStyle={{
+                  paddingLeft: 8,
+                  fontSize: 12,
+                  lineHeight: "20px",
+                }}
               />
               {scatterSeries.map((series) => (
                 <Scatter


### PR DESCRIPTION
## Summary
- increase the right margin of the new listings scatter chart so the legend has more room
- style the legend wrapper with padding and smaller text for improved readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc22da0600832aac14d6debb288325