### PR TITLE
Update New Listings analytics UI

### DIFF
--- a/src/app/datamining/lifecycle/new-listings/page.tsx
+++ b/src/app/datamining/lifecycle/new-listings/page.tsx
@@ -9,8 +9,12 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  Legend,
   CartesianGrid,
+  ReferenceLine,
+  BarChart,
+  Bar,
+  Cell,
+  LabelList,
 } from "recharts";
 
 const supabase = createClient(
@@ -26,7 +30,7 @@ type Row = {
   canonical_type: string | null;
 };
 
-type ChartDatum = Omit<Row, "company" | "ticker" | "bulletin_date"> & {
+type ChartDatum = Row & {
   company: string;
   ticker: string;
   bulletin_date: string;
@@ -142,7 +146,6 @@ export default function NewListingsPage() {
       date: new Date(`${row.bulletin_date}T00:00:00`).getTime(),
     }));
 
-  // Filtro de datas deve usar bulletin_date (string ISO), como em /Notices
   const filteredChartData = chartData.filter((row) => {
     const withinStart =
       !listingStartDate || row.bulletin_date >= listingStartDate;
@@ -160,6 +163,20 @@ export default function NewListingsPage() {
     {},
   );
 
+  const total = Object.values(typeCounts).reduce(
+    (acc, val) => acc + (val ?? 0),
+    0,
+  );
+
+  const proportionData = [...typeOptions]
+    .map((opt) => ({
+      name: opt.label,
+      value: typeCounts[opt.canonical] ?? 0,
+      percent: total ? ((typeCounts[opt.canonical] ?? 0) / total) * 100 : 0,
+      color: opt.color,
+    }))
+    .sort((a, b) => b.value - a.value);
+
   const scatterSeries = typeOptions.map((opt) => ({
     ...opt,
     data: filteredChartData.filter((row) => row.canonical_type === opt.canonical),
@@ -170,61 +187,200 @@ export default function NewListingsPage() {
     setListingEndDate(globalMaxDate);
   };
 
+  // agrupar dinamicamente por tipo
+  const groupedByType = filteredChartData.reduce<
+    Record<string, ChartDatum[]>
+  >((acc, row) => {
+    if (!row.canonical_type) return acc;
+    acc[row.canonical_type] = acc[row.canonical_type] || [];
+    acc[row.canonical_type].push(row);
+    return acc;
+  }, {});
+
+  // ticks de início de ano
+  const yearTicks: number[] = [];
+  if (globalMinDate && globalMaxDate) {
+    const startYear = new Date(globalMinDate).getFullYear();
+    const endYear = new Date(globalMaxDate).getFullYear();
+    for (let y = startYear; y <= endYear; y++) {
+      yearTicks.push(new Date(`${y}-01-01T00:00:00`).getTime());
+    }
+  }
+
+  const renderScatterChart = (
+    data: ChartDatum[],
+    color: string,
+    height = 150,
+  ) => (
+    <ResponsiveContainer width="100%" height={height}>
+      <ScatterChart margin={{ top: 10, right: 20, bottom: 10, left: 0 }}>
+        <CartesianGrid />
+        <XAxis
+          type="number"
+          dataKey="date"
+          domain={[
+            globalMinDate ? new Date(globalMinDate).getTime() : "auto",
+            globalMaxDate ? new Date(globalMaxDate).getTime() : "auto",
+          ]}
+          tickFormatter={(ts) =>
+            new Date(ts).toLocaleDateString("pt-BR", {
+              day: "2-digit",
+              month: "2-digit",
+            })
+          }
+        />
+        <YAxis
+          type="category"
+          dataKey="company"
+          tick={false}
+          axisLine={false}
+          width={0}
+        />
+        {yearTicks.map((ts) => (
+          <ReferenceLine
+            key={ts}
+            x={ts}
+            stroke="#999"
+            strokeDasharray="3 3"
+            label={{
+              value: new Date(ts).getFullYear().toString(),
+              position: "top",
+              angle: -75,
+              style: { fill: "#444", fontSize: 12 },
+            }}
+          />
+        ))}
+        <Tooltip
+          cursor={{ strokeDasharray: "3 3" }}
+          content={({ active, payload }) => {
+            if (active && payload && payload.length > 0) {
+              const datum = payload[0].payload as ChartDatum;
+              return (
+                <div className="bg-white p-2 border rounded shadow text-sm">
+                  <div>
+                    <strong>Data:</strong>{" "}
+                    {new Date(datum.date).toLocaleDateString("pt-BR")}
+                  </div>
+                  <div>
+                    <strong>Empresa:</strong> {datum.company}
+                  </div>
+                  <div>
+                    <strong>Ticker:</strong> {datum.ticker}
+                  </div>
+                  <div>
+                    <strong>Tipo:</strong> {datum.canonical_type ?? "—"}
+                  </div>
+                </div>
+              );
+            }
+            return null;
+          }}
+        />
+        <Scatter data={data} fill={color} />
+      </ScatterChart>
+    </ResponsiveContainer>
+  );
+
   return (
     <div className="p-6">
       <h2 className="text-xl font-bold mb-4">New Issuers (TSXV)</h2>
 
-      {/* Filtros */}
-      <div className="flex flex-wrap items-end gap-6 mb-4">
-        <div className="flex flex-col">
-          <label className="block text-sm font-medium mb-1">Start Date</label>
-          <input
-            type="date"
-            value={listingStartDate}
-            onChange={(e) => setListingStartDate(e.target.value)}
-            className="border rounded px-2 py-1"
-          />
-        </div>
-        <div className="flex flex-col">
-          <label className="block text-sm font-medium mb-1">End Date</label>
-          <input
-            type="date"
-            value={listingEndDate}
-            onChange={(e) => setListingEndDate(e.target.value)}
-            className="border rounded px-2 py-1"
-          />
-        </div>
-        <div className="flex items-end self-end">
+      {/* filtros + tipos + gráfico lado a lado */}
+      <div className="flex flex-wrap items-start gap-6 mb-4">
+        {/* filtros compactos */}
+        <div className="flex items-end gap-2">
+          <div className="flex flex-col">
+            <label className="text-sm font-medium">Start</label>
+            <input
+              type="date"
+              value={listingStartDate}
+              onChange={(e) => setListingStartDate(e.target.value)}
+              className="border rounded px-2 py-1"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label className="text-sm font-medium">End</label>
+            <input
+              type="date"
+              value={listingEndDate}
+              onChange={(e) => setListingEndDate(e.target.value)}
+              className="border rounded px-2 py-1"
+            />
+          </div>
           <button
             onClick={handleResetFilters}
-            className="px-3 py-1 bg-gray-200 text-black rounded hover:bg-gray-300"
+            className="mb-1 px-3 py-1 bg-gray-200 text-black rounded hover:bg-gray-300"
           >
-            🔄 Resetar filtros
+            🔄
           </button>
         </div>
-        <div>
-          <label className="block text-sm font-medium mb-1">Tipos de Boletim</label>
-          {typeOptions.map((opt) => (
-            <div key={opt.value} className="flex items-center space-x-2">
-              <input
-                type="checkbox"
-                id={opt.value}
-                checked={selectedTypes.includes(opt.canonical)}
-                onChange={() => {
-                  const canonical = opt.canonical;
-                  setSelectedTypes((prev) =>
-                    prev.includes(canonical)
-                      ? prev.filter((t) => t !== canonical)
-                      : [...prev, canonical]
-                  );
-                }}
-                className="h-4 w-4"
-              />
-              <label htmlFor={opt.value}>
-                {opt.label} ({typeCounts[opt.canonical] ?? 0})
-              </label>
+
+        {/* tipos + gráfico */}
+        <div className="flex gap-6 flex-1">
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              Tipos de Boletim
+            </label>
+            {typeOptions.map((opt) => (
+              <div key={opt.value} className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  id={opt.value}
+                  checked={selectedTypes.includes(opt.canonical)}
+                  onChange={() => {
+                    const canonical = opt.canonical;
+                    setSelectedTypes((prev) =>
+                      prev.includes(canonical)
+                        ? prev.filter((t) => t !== canonical)
+                        : [...prev, canonical]
+                    );
+                  }}
+                  className="h-4 w-4"
+                />
+                <label htmlFor={opt.value} className="flex items-center gap-2">
+                  <span
+                    className="inline-block w-3 h-3 rounded-full"
+                    style={{ backgroundColor: opt.color }}
+                  />
+                  {opt.label} ({typeCounts[opt.canonical] ?? 0})
+                </label>
+              </div>
+            ))}
+            <div className="mt-2 font-semibold text-sm text-right border-t pt-1">
+              Total: {total}
             </div>
-          ))}
+          </div>
+
+          {/* gráfico proporção */}
+          <div className="flex-1 min-w-[250px] h-[160px]">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={proportionData}
+                layout="vertical"
+                margin={{ top: 5, right: 20, bottom: 5, left: 30 }}
+              >
+                <XAxis type="number" hide />
+                <YAxis type="category" dataKey="name" width={60} />
+                <Tooltip
+                  formatter={(value: number | string) =>
+                    typeof value === "number" ? `${value.toFixed(1)}%` : value
+                  }
+                />
+                <Bar dataKey="percent">
+                  {proportionData.map((entry, idx) => (
+                    <Cell key={idx} fill={entry.color} />
+                  ))}
+                  <LabelList
+                    dataKey="percent"
+                    position="right"
+                    formatter={(label: any) =>
+                      typeof label === "number" ? `${label.toFixed(1)}%` : label
+                    }
+                  />
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       </div>
 
@@ -232,112 +388,130 @@ export default function NewListingsPage() {
         <div>⏳ Carregando...</div>
       ) : (
         <>
-          <ResponsiveContainer width="100%" height={500}>
-            <ScatterChart
-              margin={{ top: 20, right: 160, bottom: 20, left: 20 }}
-            >
-              <CartesianGrid />
-              <XAxis
-                type="number"
-                dataKey="date"
-                name="Data"
-                domain={["auto", "auto"]}
-                tickFormatter={(ts: number, index: number) => {
-                  const d = new Date(ts);
-                  const dayMonth = d.toLocaleDateString("pt-BR", {
-                    day: "2-digit",
-                    month: "2-digit",
-                  });
-                  const year = d.getFullYear();
-                  const prevYear =
-                    index > 0 && filteredChartData[index - 1]
-                      ? new Date(filteredChartData[index - 1].date).getFullYear()
-                      : null;
-                  if (index === 0 || prevYear !== year)
-                    return `${dayMonth}/${String(year).slice(2)}`;
-                  return dayMonth;
-                }}
-              />
-              {/* Alinhar ao padrão do /Notices: eixo Y oculto (empresa) */}
-              <YAxis
-                type="category"
-                dataKey="company"
-                tick={false}
-                axisLine={false}
-              />
-              <Tooltip
-                cursor={{ strokeDasharray: "3 3" }}
-                content={({ active, payload }) => {
-                  if (active && payload && payload.length > 0) {
-                    const datum = payload[0].payload as ChartDatum;
-                    return (
-                      <div className="bg-white p-2 border rounded shadow text-sm">
-                        <div>
-                          <strong>Data:</strong>{" "}
-                          {new Date(datum.date).toLocaleDateString("pt-BR")}
-                        </div>
-                        <div>
-                          <strong>Empresa:</strong> {datum.company}
-                        </div>
-                        <div>
-                          <strong>Ticker:</strong> {datum.ticker}
-                        </div>
-                        <div>
-                          <strong>Tipo:</strong> {datum.canonical_type ?? "—"}
-                        </div>
-                      </div>
-                    );
+          {/* scatter principal */}
+          <div className="mb-2">
+            <ResponsiveContainer width="100%" height={300}>
+              <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+                <CartesianGrid />
+                <XAxis
+                  type="number"
+                  dataKey="date"
+                  domain={[
+                    globalMinDate ? new Date(globalMinDate).getTime() : "auto",
+                    globalMaxDate ? new Date(globalMaxDate).getTime() : "auto",
+                  ]}
+                  tickFormatter={(ts) =>
+                    new Date(ts).toLocaleDateString("pt-BR", {
+                      day: "2-digit",
+                      month: "2-digit",
+                    })
                   }
-                  return null;
-                }}
-              />
-              <Legend
-                layout="vertical"
-                verticalAlign="top"
-                align="right"
-                wrapperStyle={{
-                  paddingLeft: 8,
-                  fontSize: 12,
-                  lineHeight: "20px",
-                }}
-              />
-              {scatterSeries.map((series) => (
-                <Scatter
-                  key={series.canonical}
-                  name={series.label}
-                  data={series.data}
-                  fill={series.color}
                 />
-              ))}
-            </ScatterChart>
-          </ResponsiveContainer>
+                <YAxis
+                  type="category"
+                  dataKey="company"
+                  tick={false}
+                  axisLine={false}
+                  width={0}
+                />
+                {yearTicks.map((ts) => (
+                  <ReferenceLine
+                    key={ts}
+                    x={ts}
+                    stroke="#999"
+                    strokeDasharray="3 3"
+                  />
+                ))}
+                <Tooltip
+                  cursor={{ strokeDasharray: "3 3" }}
+                  content={({ active, payload }) => {
+                    if (active && payload && payload.length > 0) {
+                      const datum = payload[0].payload as ChartDatum;
+                      return (
+                        <div className="bg-white p-2 border rounded shadow text-sm">
+                          <div>
+                            <strong>Data:</strong>{" "}
+                            {new Date(datum.date).toLocaleDateString("pt-BR")}
+                          </div>
+                          <div>
+                            <strong>Empresa:</strong> {datum.company}
+                          </div>
+                          <div>
+                            <strong>Ticker:</strong> {datum.ticker}
+                          </div>
+                          <div>
+                            <strong>Tipo:</strong> {datum.canonical_type ?? "—"}
+                          </div>
+                        </div>
+                      );
+                    }
+                    return null;
+                  }}
+                />
+                {scatterSeries.map((series) => (
+                  <Scatter
+                    key={series.canonical}
+                    data={series.data}
+                    fill={series.color}
+                  />
+                ))}
+              </ScatterChart>
+            </ResponsiveContainer>
+          </div>
 
-          {/* Tabela de resultados */}
+          {/* mini-scatter por tipo */}
+          <div className="flex gap-4 mt-4">
+            {typeOptions.map((opt) =>
+              selectedTypes.includes(opt.canonical) ? (
+                <div key={opt.value} className="w-1/3">
+                  <h3 className="text-sm font-semibold mb-1 text-center flex items-center justify-center gap-2">
+                    <span
+                      className="inline-block w-3 h-3 rounded-full"
+                      style={{ backgroundColor: opt.color }}
+                    />
+                    {opt.label}
+                  </h3>
+                  {renderScatterChart(
+                    scatterSeries.find((s) => s.canonical === opt.canonical)
+                      ?.data || [],
+                    opt.color,
+                  )}
+                </div>
+              ) : null,
+            )}
+          </div>
+
+          {/* tabela agrupada por tipo */}
           <div className="mt-6 border rounded-lg p-4 bg-gray-50">
             <h2 className="text-lg font-semibold mb-2">Resultados</h2>
-            {filteredChartData.length === 0 ? (
-              <p className="text-gray-400">Nenhuma empresa encontrada no filtro.</p>
+            {Object.keys(groupedByType).length === 0 ? (
+              <p className="text-gray-400">Nenhuma empresa encontrada.</p>
             ) : (
-              <table className="w-full text-sm border">
-                <thead>
-                  <tr className="bg-gray-200">
-                    <th className="border px-2 py-1 text-left">Empresa</th>
-                    <th className="border px-2 py-1 text-left">Ticker</th>
-                    <th className="border px-2 py-1 text-left">Data</th>
-                    <th className="border px-2 py-1 text-left">Tipo</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredChartData.map((row) => (
-                    <tr key={row.id} className="hover:bg-gray-100">
-                      <td className="border px-2 py-1">{row.company}</td>
-                      <td className="border px-2 py-1">{row.ticker}</td>
-                      <td className="border px-2 py-1">{row.bulletin_date}</td>
-                      <td className="border px-2 py-1">{row.canonical_type}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              Object.entries(groupedByType).map(([type, rows]) => (
+                <details key={type} className="mb-4 border rounded">
+                  <summary className="cursor-pointer bg-gray-200 px-2 py-1 font-medium">
+                    {type} ({rows.length})
+                  </summary>
+                  <table className="w-full text-sm border">
+                    <thead>
+                      <tr className="bg-gray-100">
+                        <th className="border px-2 py-1 text-left">Empresa</th>
+                        <th className="border px-2 py-1 text-left">Ticker</th>
+                        <th className="border px-2 py-1 text-left">Data</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((row) => (
+                        <tr key={row.id} className="hover:bg-gray-50">
+                          <td className="border px-2 py-1">{row.company}</td>
+                          <td className="border px-2 py-1">{row.ticker}</td>
+                          <td className="border px-2 py-1">{row.bulletin_date}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </details>
+              ))
             )}
           </div>
         </>
@@ -345,3 +519,4 @@ export default function NewListingsPage() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- enhance the new listings page with proportion charts, yearly reference lines, and grouped results
- add mini scatter charts and interactive filters for selected bulletin types
- extend tooltip information and share type counts across the layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4e47b6b4832ab85e1edf7619ac2f