### PR TITLE
Refactor JRpedia to path-based hierarchy

### DIFF
--- a/src/app/jrpedia/components/GlossaryForm.tsx
+++ b/src/app/jrpedia/components/GlossaryForm.tsx
@@ -1,199 +1,253 @@
 "use client";
-import { useEffect, useState } from "react";
-import { createClient } from "@supabase/supabase-js";
+
+import { useEffect, useMemo, useState } from "react";
 import { GlossaryRow, GlossaryRowInput } from "../types";
 
 type GlossaryFormProps = {
   initialData?: GlossaryRow;
+  initialParentPath?: string | null;
   onSave: (data: GlossaryRowInput) => Promise<void>;
   onCancel: () => void;
 };
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-);
+const EMPTY_FORM: GlossaryRowInput = {
+  term: "",
+  pt: "",
+  en: "",
+  fr: "",
+  definition_pt: "",
+  definition_en: "",
+  definition_fr: "",
+  category: "General",
+  fonte: "",
+  tags: [],
+  parent_path: null,
+};
 
-export default function GlossaryForm({ initialData, onSave, onCancel }: GlossaryFormProps) {
-  const [form, setForm] = useState<GlossaryRowInput>({
-    term: initialData?.term ?? "",
-    pt: initialData?.pt ?? "",
-    en: initialData?.en ?? "",
-    fr: initialData?.fr ?? "",
-    definition_pt: initialData?.definition_pt ?? "",
-    definition_en: initialData?.definition_en ?? "",
-    definition_fr: initialData?.definition_fr ?? "",
-    category: initialData?.category ?? "General",
-    fonte: initialData?.fonte ?? "",
-    tags: initialData?.tags ?? [],
-    parent_path: (initialData as any)?.parent_path ?? "",
-  });
+export default function GlossaryForm({
+  initialData,
+  initialParentPath,
+  onSave,
+  onCancel,
+}: GlossaryFormProps) {
+  const resolvedInitial = useMemo<GlossaryRowInput>(() => {
+    if (!initialData) {
+      return {
+        ...EMPTY_FORM,
+        parent_path: initialParentPath ?? null,
+      };
+    }
 
+    return {
+      term: initialData.term ?? "",
+      pt: initialData.pt ?? "",
+      en: initialData.en ?? "",
+      fr: initialData.fr ?? "",
+      definition_pt: initialData.definition_pt ?? "",
+      definition_en: initialData.definition_en ?? "",
+      definition_fr: initialData.definition_fr ?? "",
+      category: initialData.category ?? "General",
+      fonte: initialData.fonte ?? "",
+      tags: initialData.tags ?? [],
+      parent_path: initialData.parent_path ?? null,
+      path: initialData.path ?? null,
+    };
+  }, [initialData, initialParentPath]);
+
+  const [form, setForm] = useState<GlossaryRowInput>(resolvedInitial);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    setForm({
-      term: initialData?.term ?? "",
-      pt: initialData?.pt ?? "",
-      en: initialData?.en ?? "",
-      fr: initialData?.fr ?? "",
-      definition_pt: initialData?.definition_pt ?? "",
-      definition_en: initialData?.definition_en ?? "",
-      definition_fr: initialData?.definition_fr ?? "",
-      category: initialData?.category ?? "General",
-      fonte: initialData?.fonte ?? "",
-      tags: initialData?.tags ?? [],
-      parent_path: (initialData as any)?.parent_path ?? "",
-    });
-  }, [initialData]);
+    setForm(resolvedInitial);
+  }, [resolvedInitial]);
 
-  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
-    const { name, value } = e.target;
-    setForm({ ...form, [name]: value });
+  function handleChange(
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
+    const { name, value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
   }
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
     setLoading(true);
-    await onSave(form);
+
+    const sanitizedParentPath =
+      typeof form.parent_path === "string" && form.parent_path.trim().length > 0
+        ? form.parent_path.trim()
+        : null;
+
+    const payload: GlossaryRowInput = {
+      ...form,
+      parent_path: sanitizedParentPath,
+    };
+
+    await onSave(payload);
     setLoading(false);
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4 w-[560px]">
-      {/* Termo base */}
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 w-full max-w-[560px] text-white"
+    >
       <div>
-        <label className="block text-sm font-bold">Termo base</label>
+        <label className="block text-sm font-bold text-[#d4af37]">Termo base</label>
         <input
           name="term"
           value={form.term}
           onChange={handleChange}
-          className="border p-2 w-full rounded"
+          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
           required
         />
       </div>
 
-      {/* Parent Path */}
+      {form.path && (
+        <div>
+          <span className="block text-xs uppercase tracking-wide text-gray-400">Caminho atual</span>
+          <div className="mt-1 rounded border border-[#2e3b4a] bg-[#13202c] px-3 py-2 text-sm">
+            {form.path}
+          </div>
+        </div>
+      )}
+
       <div>
-        <label className="block text-sm font-semibold">Parent Path</label>
+        <label className="block text-sm font-semibold text-[#d4af37]">Caminho do pai</label>
         <input
           type="text"
           name="parent_path"
           placeholder="Ex: 1.1 ou 1.1.1"
-          value={(form as any).parent_path ?? ""}
-          onChange={(e) =>
-            setForm({
-              ...form,
-              parent_path: e.target.value.trim(),
-            })
+          value={
+            typeof form.parent_path === "string" ? form.parent_path : form.parent_path ?? ""
           }
-          className="border p-2 w-full rounded bg-[#1e2a38] text-white placeholder-gray-400"
+          onChange={(event) =>
+            setForm((prev) => ({
+              ...prev,
+              parent_path: event.target.value,
+            }))
+          }
+          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white placeholder-gray-400 focus:border-[#d4af37] focus:outline-none"
         />
         <p className="text-xs text-gray-400 mt-1">
           Indique o caminho do termo pai (ex: 1.1.1). Deixe vazio para nó raiz.
         </p>
       </div>
 
-      {/* Traduções */}
       <div className="grid grid-cols-3 gap-2">
         <div>
-          <label className="block text-sm">PT</label>
-          <input name="pt" value={form.pt || ""} onChange={handleChange} className="border p-2 w-full rounded" />
+          <label className="block text-sm text-[#d4af37]">PT</label>
+          <input
+            name="pt"
+            value={form.pt ?? ""}
+            onChange={handleChange}
+            className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
+          />
         </div>
         <div>
-          <label className="block text-sm">EN</label>
-          <input name="en" value={form.en || ""} onChange={handleChange} className="border p-2 w-full rounded" />
+          <label className="block text-sm text-[#d4af37]">EN</label>
+          <input
+            name="en"
+            value={form.en ?? ""}
+            onChange={handleChange}
+            className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
+          />
         </div>
         <div>
-          <label className="block text-sm">FR</label>
-          <input name="fr" value={form.fr || ""} onChange={handleChange} className="border p-2 w-full rounded" />
+          <label className="block text-sm text-[#d4af37]">FR</label>
+          <input
+            name="fr"
+            value={form.fr ?? ""}
+            onChange={handleChange}
+            className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
+          />
         </div>
       </div>
 
-      {/* Definições */}
       <div>
-        <label className="block text-sm">Definição PT</label>
+        <label className="block text-sm text-[#d4af37]">Definição PT</label>
         <textarea
           name="definition_pt"
-          value={form.definition_pt || ""}
+          value={form.definition_pt ?? ""}
           onChange={handleChange}
-          className="border p-2 w-full rounded"
+          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
         />
       </div>
       <div>
-        <label className="block text-sm">Definição EN</label>
+        <label className="block text-sm text-[#d4af37]">Definição EN</label>
         <textarea
           name="definition_en"
-          value={form.definition_en || ""}
+          value={form.definition_en ?? ""}
           onChange={handleChange}
-          className="border p-2 w-full rounded"
+          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
         />
       </div>
       <div>
-        <label className="block text-sm">Definição FR</label>
+        <label className="block text-sm text-[#d4af37]">Definição FR</label>
         <textarea
           name="definition_fr"
-          value={form.definition_fr || ""}
+          value={form.definition_fr ?? ""}
           onChange={handleChange}
-          className="border p-2 w-full rounded"
+          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
         />
       </div>
 
-      {/* Categoria */}
       <div>
-        <label className="block text-sm">Categoria</label>
+        <label className="block text-sm text-[#d4af37]">Categoria</label>
         <input
           name="category"
-          value={form.category || ""}
+          value={form.category ?? ""}
           onChange={handleChange}
-          className="border p-2 w-full rounded"
+          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
         />
       </div>
 
-      {/* Fonte */}
       <div>
-        <label className="block text-sm">Fonte</label>
+        <label className="block text-sm text-[#d4af37]">Fonte</label>
         <input
           type="text"
           name="fonte"
           value={form.fonte}
           onChange={handleChange}
-          className="border p-2 w-full rounded"
+          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
         />
       </div>
 
-      {/* Tags */}
       <div>
-        <label className="block text-sm">Tags (separadas por vírgula)</label>
+        <label className="block text-sm text-[#d4af37]">
+          Tags (separadas por vírgula)
+        </label>
         <input
           name="tags"
-          value={form.tags?.join(", ") || ""}
-          onChange={(e) =>
-            setForm({
-              ...form,
-              tags: e.target.value
-                .split(",")
-                .map((t) => t.trim())
-                .filter((t) => t.length > 0),
-            })
-          }
-          className="border p-2 w-full rounded"
+          value={(form.tags ?? []).join(", ")}
+          onChange={(event) => {
+            const nextTags = event.target.value
+              .split(",")
+              .map((tag) => tag.trim())
+              .filter((tag) => tag.length > 0);
+            setForm((prev) => ({
+              ...prev,
+              tags: nextTags.length > 0 ? nextTags : [],
+            }));
+          }}
+          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white focus:border-[#d4af37] focus:outline-none"
         />
       </div>
 
-      {/* Ações */}
       <div className="flex justify-end space-x-2 pt-2">
         <button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 bg-gray-300 rounded"
+          className="px-4 py-2 rounded border border-[#d4af37] text-[#d4af37] hover:bg-[#2e3b4a]"
         >
           Cancelar
         </button>
         <button
           type="submit"
           disabled={loading}
-          className="px-4 py-2 bg-[#d4af37] text-black font-bold rounded"
+          className="px-4 py-2 rounded bg-[#d4af37] text-black font-bold hover:bg-[#f0c75e] disabled:opacity-70"
         >
           {loading ? "Salvando..." : "Salvar"}
         </button>

--- a/src/app/jrpedia/components/Modal.tsx
+++ b/src/app/jrpedia/components/Modal.tsx
@@ -6,26 +6,45 @@ type ModalProps = {
   onClose: () => void;
   title?: string;
   children: ReactNode;
+  contentClassName?: string;
+  titleClassName?: string;
 };
 
-export default function Modal({ isOpen, onClose, title, children }: ModalProps) {
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  contentClassName,
+  titleClassName,
+}: ModalProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-50">
-      <div className="bg-white rounded-lg shadow-lg w-full max-w-lg p-6 relative">
-        {/* Botão Fechar */}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div
+        className={`relative w-full max-w-lg rounded-lg bg-white p-6 shadow-lg ${
+          contentClassName ?? ""
+        }`}
+      >
         <button
           onClick={onClose}
-          className="absolute top-3 right-3 text-gray-500 hover:text-black"
+          className="absolute right-3 top-3 text-gray-400 transition hover:text-gray-600"
+          aria-label="Fechar modal"
         >
           ✖
         </button>
 
-        {/* Título opcional */}
-        {title && <h2 className="text-xl font-bold mb-4">{title}</h2>}
+        {title && (
+          <h2
+            className={`mb-4 text-xl font-bold ${
+              titleClassName ?? "text-gray-900"
+            }`}
+          >
+            {title}
+          </h2>
+        )}
 
-        {/* Conteúdo injetado */}
         <div>{children}</div>
       </div>
     </div>

--- a/src/app/jrpedia/types.ts
+++ b/src/app/jrpedia/types.ts
@@ -16,7 +16,9 @@ export type GlossaryRow = {
   category: string | null;
   fonte: string;
   tags: string[] | null;
-  parent_id: number | null;
+  parent_id?: number | null;
+  path?: string | null;
+  parent_path?: string | null;
 };
 
 export type GlossaryRowInput = Omit<GlossaryRow, "id">;
@@ -49,7 +51,7 @@ export type CrudModalsProps = {
   fetchEntries: () => void;
   showNewModal: boolean;
   setShowNewModal: (v: boolean) => void;
-  newParentId: number | null;
+  newParentPath: string | null;
   showEditModal: boolean;
   setShowEditModal: (v: boolean) => void;
 };


### PR DESCRIPTION
## Summary
- update the JRpedia glossary form to capture parent paths, surface the current path, and restyle inputs for the dark theme
- refresh the CRUD modals, sidebar, and search UI to display path metadata and rely exclusively on the path hierarchy
- rebuild the JRpedia page logic and types so glossary data loads ordered by path and renders a nested tree without parent IDs

## Testing
- NEXT_PUBLIC_SUPABASE_URL="http://localhost" NEXT_PUBLIC_SUPABASE_ANON_KEY="dummy" SUPABASE_SERVICE_KEY="dummy" SUPABASE_URL="http://localhost" npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4554a5ea0832aa480c2de92858fd7