### PR TITLE
Refactor glossary form parent selection UX

### DIFF
--- a/src/app/jrpedia/components/GlossaryForm.tsx
+++ b/src/app/jrpedia/components/GlossaryForm.tsx
@@ -81,7 +81,7 @@ export default function GlossaryForm({
 
     async function fetchTerms() {
       const { data, error } = await supabase
-        .from<GlossaryTermSummary>("glossary")
+        .from("glossary")
         .select("id, term, path")
         .order("path");
 

--- a/src/app/jrpedia/components/GlossaryForm.tsx
+++ b/src/app/jrpedia/components/GlossaryForm.tsx
@@ -1,7 +1,19 @@
 "use client";
 
+import { createClient } from "@supabase/supabase-js";
 import { useEffect, useMemo, useState } from "react";
 import { GlossaryRow, GlossaryRowInput } from "../types";
+
+type GlossaryTermSummary = {
+  id: number;
+  term: string;
+  path: string | null;
+};
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+);
 
 type GlossaryFormProps = {
   initialData?: GlossaryRow;
@@ -22,6 +34,7 @@ const EMPTY_FORM: GlossaryRowInput = {
   fonte: "",
   tags: [],
   parent_path: null,
+  parent_name: "",
 };
 
 export default function GlossaryForm({
@@ -51,15 +64,85 @@ export default function GlossaryForm({
       tags: initialData.tags ?? [],
       parent_path: initialData.parent_path ?? null,
       path: initialData.path ?? null,
+      parent_name: "",
     };
   }, [initialData, initialParentPath]);
 
   const [form, setForm] = useState<GlossaryRowInput>(resolvedInitial);
   const [loading, setLoading] = useState(false);
+  const [allTerms, setAllTerms] = useState<GlossaryTermSummary[]>([]);
 
   useEffect(() => {
     setForm(resolvedInitial);
   }, [resolvedInitial]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchTerms() {
+      const { data, error } = await supabase
+        .from<GlossaryTermSummary>("glossary")
+        .select("id, term, path")
+        .order("path");
+
+      if (error) {
+        console.error("Failed to load glossary terms", error.message);
+        return;
+      }
+
+      if (!isMounted || !data) {
+        return;
+      }
+
+      setAllTerms(data);
+    }
+
+    void fetchTerms();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (allTerms.length === 0) {
+      return;
+    }
+
+    setForm((previous) => {
+      const currentParentPath =
+        typeof previous.parent_path === "string" && previous.parent_path.length > 0
+          ? previous.parent_path
+          : null;
+      const currentParentName = previous.parent_name ?? "";
+      let nextParentName = currentParentName;
+      let nextParentPath = currentParentPath;
+
+      if (currentParentPath) {
+        const match = allTerms.find((term) => term.path === currentParentPath.trim());
+        if (match && match.term !== currentParentName) {
+          nextParentName = match.term;
+        }
+      } else if (currentParentName.length > 0) {
+        const match = allTerms.find(
+          (term) => term.term.toLowerCase() === currentParentName.toLowerCase(),
+        );
+        if (match && match.path !== currentParentPath) {
+          nextParentPath = match.path ?? null;
+        }
+      }
+
+      if (nextParentName === currentParentName && nextParentPath === currentParentPath) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        parent_name: nextParentName,
+        parent_path: nextParentPath,
+      };
+    });
+  }, [allTerms]);
 
   function handleChange(
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -71,6 +154,69 @@ export default function GlossaryForm({
     }));
   }
 
+  const handleParentPathChange = (value: string) => {
+    const trimmedValue = value.trim();
+    const match =
+      trimmedValue.length > 0
+        ? allTerms.find((term) => term.path === trimmedValue)
+        : undefined;
+
+    setForm((previous) => {
+      const nextParentName = match ? match.term : "";
+      const nextParentPath = match
+        ? match.path ?? null
+        : value.length > 0
+        ? value
+        : null;
+
+      if (
+        previous.parent_path === nextParentPath &&
+        (previous.parent_name ?? "") === nextParentName
+      ) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        parent_path: nextParentPath,
+        parent_name: nextParentName,
+      };
+    });
+  };
+
+  const handleParentTermChange = (value: string) => {
+    const trimmedValue = value.trim();
+    const match =
+      trimmedValue.length > 0
+        ? allTerms.find(
+            (term) => term.term.toLowerCase() === trimmedValue.toLowerCase(),
+          )
+        : undefined;
+
+    setForm((previous) => {
+      const nextParentPath = match
+        ? match.path ?? null
+        : trimmedValue.length === 0
+        ? null
+        : previous.parent_path ?? null;
+
+      const nextParentName = match ? match.term : value;
+
+      if (
+        (previous.parent_name ?? "") === nextParentName &&
+        previous.parent_path === nextParentPath
+      ) {
+        return previous;
+      }
+
+      return {
+        ...previous,
+        parent_name: nextParentName,
+        parent_path: nextParentPath,
+      };
+    });
+  };
+
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
     setLoading(true);
@@ -80,9 +226,15 @@ export default function GlossaryForm({
         ? form.parent_path.trim()
         : null;
 
+    const sanitizedParentName =
+      form.parent_name && form.parent_name.trim().length > 0
+        ? form.parent_name.trim()
+        : undefined;
+
     const payload: GlossaryRowInput = {
       ...form,
       parent_path: sanitizedParentPath,
+      parent_name: sanitizedParentName,
     };
 
     await onSave(payload);
@@ -92,10 +244,10 @@ export default function GlossaryForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="space-y-4 w-full max-w-[560px] text-white"
+      className="space-y-4 w-full max-w-[700px] max-h-[90vh] overflow-y-auto text-white"
     >
       <div>
-        <label className="block text-sm font-bold text-[#d4af37]">Termo base</label>
+        <label className="block text-sm font-bold text-gray-200">Termo base</label>
         <input
           name="term"
           value={form.term}
@@ -115,30 +267,47 @@ export default function GlossaryForm({
       )}
 
       <div>
-        <label className="block text-sm font-semibold text-[#d4af37]">Caminho do pai</label>
-        <input
-          type="text"
-          name="parent_path"
-          placeholder="Ex: 1.1 ou 1.1.1"
-          value={
-            typeof form.parent_path === "string" ? form.parent_path : form.parent_path ?? ""
-          }
-          onChange={(event) =>
-            setForm((prev) => ({
-              ...prev,
-              parent_path: event.target.value,
-            }))
-          }
-          className="border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white placeholder-gray-400 focus:border-[#d4af37] focus:outline-none"
-        />
-        <p className="text-xs text-gray-400 mt-1">
-          Indique o caminho do termo pai (ex: 1.1.1). Deixe vazio para nó raiz.
+        <label className="block text-sm font-semibold text-gray-200">parent_path</label>
+        <div className="mt-2 grid gap-3 md:grid-cols-2">
+          <div>
+            <span className="block text-xs uppercase tracking-wide text-gray-400">Path</span>
+            <input
+              type="text"
+              name="parent_path"
+              placeholder="e.g. 1.1 or 1.1.1"
+              value={typeof form.parent_path === "string" ? form.parent_path : form.parent_path ?? ""}
+              onChange={(event) => handleParentPathChange(event.target.value)}
+              className="mt-1 border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white placeholder-gray-400 focus:border-[#d4af37] focus:outline-none"
+            />
+          </div>
+          <div>
+            <span className="block text-xs uppercase tracking-wide text-gray-400">Term</span>
+            <input
+              type="text"
+              list="parent-term-options"
+              name="parent_name"
+              placeholder="Search parent term"
+              value={form.parent_name ?? ""}
+              onChange={(event) => handleParentTermChange(event.target.value)}
+              className="mt-1 border border-[#2e3b4a] bg-[#1c2833] p-2 w-full rounded text-white placeholder-gray-400 focus:border-[#d4af37] focus:outline-none"
+            />
+            <datalist id="parent-term-options">
+              {allTerms.map((term) => (
+                <option key={term.id} value={term.term}>
+                  {term.path ?? ""}
+                </option>
+              ))}
+            </datalist>
+          </div>
+        </div>
+        <p className="text-xs text-gray-400 mt-2">
+          Leave both fields empty to create a root-level term.
         </p>
       </div>
 
       <div className="grid grid-cols-3 gap-2">
         <div>
-          <label className="block text-sm text-[#d4af37]">PT</label>
+          <label className="block text-sm text-gray-200">PT</label>
           <input
             name="pt"
             value={form.pt ?? ""}
@@ -147,7 +316,7 @@ export default function GlossaryForm({
           />
         </div>
         <div>
-          <label className="block text-sm text-[#d4af37]">EN</label>
+          <label className="block text-sm text-gray-200">EN</label>
           <input
             name="en"
             value={form.en ?? ""}
@@ -156,7 +325,7 @@ export default function GlossaryForm({
           />
         </div>
         <div>
-          <label className="block text-sm text-[#d4af37]">FR</label>
+          <label className="block text-sm text-gray-200">FR</label>
           <input
             name="fr"
             value={form.fr ?? ""}
@@ -167,7 +336,7 @@ export default function GlossaryForm({
       </div>
 
       <div>
-        <label className="block text-sm text-[#d4af37]">Definição PT</label>
+        <label className="block text-sm text-gray-200">Definição PT</label>
         <textarea
           name="definition_pt"
           value={form.definition_pt ?? ""}
@@ -176,7 +345,7 @@ export default function GlossaryForm({
         />
       </div>
       <div>
-        <label className="block text-sm text-[#d4af37]">Definição EN</label>
+        <label className="block text-sm text-gray-200">Definição EN</label>
         <textarea
           name="definition_en"
           value={form.definition_en ?? ""}
@@ -185,7 +354,7 @@ export default function GlossaryForm({
         />
       </div>
       <div>
-        <label className="block text-sm text-[#d4af37]">Definição FR</label>
+        <label className="block text-sm text-gray-200">Definição FR</label>
         <textarea
           name="definition_fr"
           value={form.definition_fr ?? ""}
@@ -195,7 +364,7 @@ export default function GlossaryForm({
       </div>
 
       <div>
-        <label className="block text-sm text-[#d4af37]">Categoria</label>
+        <label className="block text-sm text-gray-200">Categoria</label>
         <input
           name="category"
           value={form.category ?? ""}
@@ -205,7 +374,7 @@ export default function GlossaryForm({
       </div>
 
       <div>
-        <label className="block text-sm text-[#d4af37]">Fonte</label>
+        <label className="block text-sm text-gray-200">Fonte</label>
         <input
           type="text"
           name="fonte"
@@ -216,7 +385,7 @@ export default function GlossaryForm({
       </div>
 
       <div>
-        <label className="block text-sm text-[#d4af37]">
+        <label className="block text-sm text-gray-200">
           Tags (separadas por vírgula)
         </label>
         <input

--- a/src/app/jrpedia/types.ts
+++ b/src/app/jrpedia/types.ts
@@ -21,7 +21,9 @@ export type GlossaryRow = {
   parent_path?: string | null;
 };
 
-export type GlossaryRowInput = Omit<GlossaryRow, "id">;
+export type GlossaryRowInput = Omit<GlossaryRow, "id"> & {
+  parent_name?: string;
+};
 
 export type GlossaryNode = GlossaryRow & { children: GlossaryNode[] };
 


### PR DESCRIPTION
## Summary
- add a Supabase-backed cache of glossary paths and expose parent path/term autocomplete inputs
- restyle the glossary form to fit the updated JRpedia modal layout and dark theme
- extend glossary form typing with the optional parent_name helper field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e45f31824c832a9949ba83fa2af879