### PR TITLE
Update JRpedia UI backgrounds to white

### DIFF
--- a/src/app/jrpedia/components/GlossaryForm.tsx
+++ b/src/app/jrpedia/components/GlossaryForm.tsx
@@ -244,7 +244,7 @@ export default function GlossaryForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className="space-y-4 w-full max-w-[700px] max-h-[90vh] overflow-y-auto text-white"
+      className="space-y-4 w-full max-w-[700px] max-h-[90vh] overflow-y-auto text-black"
     >
       <div>
         <label className="block text-sm font-bold text-gray-200">Termo base</label>
@@ -260,7 +260,7 @@ export default function GlossaryForm({
       {form.path && (
         <div>
           <span className="block text-xs uppercase tracking-wide text-gray-400">Caminho atual</span>
-          <div className="mt-1 rounded border border-[#2e3b4a] bg-[#13202c] px-3 py-2 text-sm">
+          <div className="mt-1 rounded border border-gray-300 bg-white px-3 py-2 text-sm">
             {form.path}
           </div>
         </div>

--- a/src/app/jrpedia/components/Sidebar.tsx
+++ b/src/app/jrpedia/components/Sidebar.tsx
@@ -59,7 +59,7 @@ export default function Sidebar({
             setSelectedTerm(node);
           }}
           className={`block w-full text-left px-2 py-1 rounded ${fontSize} ${
-            isSelected ? "bg-[#d4af37] text-black" : "hover:bg-[#2e3b4a]"
+            isSelected ? "bg-[#d4af37] text-black" : "hover:bg-gray-200"
           }`}
           type="button"
         >
@@ -88,7 +88,7 @@ export default function Sidebar({
   }
 
   return (
-    <aside className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-700 bg-[#1e2a38] text-white shadow-sm">
+    <aside className="ml-2 flex w-64 min-w-[220px] max-w-[400px] resize-x flex-col overflow-hidden rounded-md border border-gray-300 bg-white text-black shadow-sm">
       <div className="flex items-center justify-between px-3 pt-4 pb-2">
         <h3 className="text-lg font-bold text-[#d4af37]">JRpedia</h3>
         <button
@@ -101,7 +101,7 @@ export default function Sidebar({
         </button>
       </div>
       <div className="flex-1 overflow-hidden pb-3">
-        <div className="h-full border-r border-gray-600 bg-[#1c2833] pt-2">
+        <div className="h-full border-r border-gray-200 bg-white pt-2">
           <div className="h-full space-y-1 overflow-y-auto pr-1 text-sm scrollbar-hide">
             {tree.map((node) => (
               <TreeNode


### PR DESCRIPTION
## Summary
- switch JRpedia glossary form container styling to use white backgrounds and darker borders
- update JRpedia sidebar container and hover states to match the lighter color scheme

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e46a9ada44832a8a17ce9f9e1baf6f